### PR TITLE
Restore topN view using ECS field

### DIFF
--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
     "pdfmake": "^0.2.4",
     "peggy": "^1.2.0",
     "pixi-viewport": "^4.34.4",
-    "pixi.js": "^6.2.1",
+    "pixi.js": "^6.2.2",
     "pluralize": "3.1.0",
     "pngjs": "^3.4.0",
     "polished": "^3.7.2",

--- a/src/plugins/profiling/server/routes/search_flameChart.ts
+++ b/src/plugins/profiling/server/routes/search_flameChart.ts
@@ -52,7 +52,7 @@ export function registerFlameChartSearchRoute(router: IRouter<DataRequestHandler
                             },
                             {
                               range: {
-                                TimeStamp: {
+                                '@timestamp': {
                                   gte: timeFrom,
                                   lt: timeTo,
                                   format: 'epoch_second',
@@ -107,7 +107,7 @@ export function registerFlameChartSearchRoute(router: IRouter<DataRequestHandler
                         },
                         {
                           range: {
-                            TimeStamp: {
+                            '@timestamp': {
                               gte: timeFrom,
                               lt: timeTo,
                               format: 'epoch_second',
@@ -121,7 +121,7 @@ export function registerFlameChartSearchRoute(router: IRouter<DataRequestHandler
                   aggs: {
                     histogram: {
                       auto_date_histogram: {
-                        field: 'TimeStamp',
+                        field: '@timestamp',
                         buckets: 100,
                       },
                       aggs: {

--- a/src/plugins/profiling/server/routes/search_topN.ts
+++ b/src/plugins/profiling/server/routes/search_topN.ts
@@ -52,7 +52,7 @@ export function queryTopNCommon(
                         },
                         {
                           range: {
-                            TimeStamp: {
+                            '@timestamp': {
                               gte: timeFrom,
                               lt: timeTo,
                               format: 'epoch_second',
@@ -66,7 +66,7 @@ export function queryTopNCommon(
                   aggs: {
                     histogram: {
                       auto_date_histogram: {
-                        field: 'TimeStamp',
+                        field: '@timestamp',
                         buckets: 100,
                       },
                       aggs: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3811,185 +3811,185 @@
     which "^2.0.1"
     winston "^3.0.0"
 
-"@pixi/accessibility@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/accessibility/-/accessibility-6.2.1.tgz#30935541843244865f0977da846e5d9851fce6b2"
-  integrity sha512-zXgXx3BostasR69a68BDGVMEjL5CWBct+LtongU1T8HgdXbu2BPaZ/Z679pMj23+5oAR0mUeoH7qTTyRQ2kS3g==
+"@pixi/accessibility@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/accessibility/-/accessibility-6.2.2.tgz#0c46b59d11c3e4b841bff5153116e2d17d028a24"
+  integrity sha512-/mXRXCw67bmPY/OZ1Y1p747h3SSg7eqacIChAUJohjbcJK0R2EJRD2uVTspVIUpHPJA0ECNGBpKqk0C1Yzkj2w==
 
-"@pixi/app@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/app/-/app-6.2.1.tgz#3caec8530fe5b80d8c2d47a84249c11f89ed3281"
-  integrity sha512-J1dlu4PTF6O9WfHKTs0pg3NSePW2+8M2yMrivR7R/Z3CmmebnRiquua7U/avQXkLVJBwGdSyij2e6fN8dvnUXw==
+"@pixi/app@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/app/-/app-6.2.2.tgz#45c3dba327a6500d6b9322048950499a5588ec22"
+  integrity sha512-YBzVaSZGA842w2gsgqzxYwQMXeu2JZmSyiybi4raFsA35iOeMurXy7sEs5NP9JO+cjobJyx6echuHzZpKUjWsQ==
 
-"@pixi/compressed-textures@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/compressed-textures/-/compressed-textures-6.2.1.tgz#5f64f542c8a8cde99feee9e53aa2e3675554cf9b"
-  integrity sha512-ZtmitA5ClIBqBo/dR1pd2n/y/xxOC+UKAj1S04FZiXaekYjmcsPUKxbq2Mgp8Qk2PBdz98HSQ4/xOGAYBMWrdQ==
+"@pixi/compressed-textures@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/compressed-textures/-/compressed-textures-6.2.2.tgz#8860283058ab931c26dde27daa328e0a7de11a65"
+  integrity sha512-ZjiqYCE6nGtsKTRa6w4W6Krh3vo4M3WT6lrP+VW6BfgUx3quEURt5GVFsFZrJpWF4yI1fShFmjBUOerrTLJGRQ==
 
-"@pixi/constants@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/constants/-/constants-6.2.1.tgz#950ea81c69bdbc220a0b548eb48742c35a6a08ab"
-  integrity sha512-Dppt6rjYP4mIvJCY1I38XhPSfXoOm+A+ERKljLjcvcxVAMhqCTVz3YMp2cUzaio6DtQutiQ6tT06M40xlBZ/lA==
+"@pixi/constants@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/constants/-/constants-6.2.2.tgz#53a2d0e7f3d16d0400985d81005a076c25b0b32a"
+  integrity sha512-BKSoj/5SI+pQEatuCG5kXXWtCZmZZNMhfhXeqvYO/WNZ+LDxm6F4pllf0t7KjGs1ZBpNxVf6fyngF9Q5r3MgJQ==
 
-"@pixi/core@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/core/-/core-6.2.1.tgz#c6a4d750ff059cb5a78aa85202cceda8a452fcf5"
-  integrity sha512-Ndh4/sNXWEkDeU5waWBCsMMPPaQv5uXLyepPXJE0emHBtgJOjKEHa79hrr0p1I2KN7Q8+mw8WlK55yVGuHroIA==
+"@pixi/core@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/core/-/core-6.2.2.tgz#badf9c03e3a07835b92d1a3868363d8e5083cf13"
+  integrity sha512-XAqgdJ1w9k1ZUBXECm19rcnN2ngm+tOP74HkGw4qQay0biM3JS+wtX4fWQmZNGr8krf6lJrNbsghbtUy70uUaw==
 
-"@pixi/display@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/display/-/display-6.2.1.tgz#f2859ac5e5fd98f5049f089af8a0654d6702162e"
-  integrity sha512-4taHTgQeAWXrxB4WV0CsyarFEVuI8seKU+12S57c8nQGRYESfDUx4jFatWfgMHY2xCNwCdPTCvlSJzT5ou8VWA==
+"@pixi/display@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/display/-/display-6.2.2.tgz#6e8ef26f2ed686c03d71d8bb5b92e6222cb23563"
+  integrity sha512-8a0R+9rjlUUjb13nBA6ZNj9gygJqt38B63uIZ2inkhxpIQf0CLo2hNxkqCqXiMeRuGmOw1n6neEDMnHO1Ks+xA==
 
-"@pixi/extract@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/extract/-/extract-6.2.1.tgz#23cce92537ea45e1d6af381521f6f8bb4ed53f75"
-  integrity sha512-11MTxqXaZlsYRf9QumEDqZXoTb2RlIwpL42k7CnY7ycP+pu8TV+HB5NfLzFltCjnzXuBbl0/bz8eYeU5cSlVkA==
+"@pixi/extract@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/extract/-/extract-6.2.2.tgz#f8d682dbf4c29ad2bbbed0bf710c63fcfdcadc7c"
+  integrity sha512-w3gW1/VoHNqFEUNGRQBKm8dCdg816etbpbLExWctmPpNdyxos5N7DF44UMRFg40GPVBBNzYissrH/ojca4PFIA==
 
-"@pixi/filter-alpha@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/filter-alpha/-/filter-alpha-6.2.1.tgz#86ef8588177b5f4b88791782342ef0846fff2ab4"
-  integrity sha512-f/xSY+T9JnpzrtB2F1EOsGr6urgln6Wdr/NQgVk13L/g8jrM/PhMlbDsodEwf5IL/2xRjAFwYjCFMgzWVXALkw==
+"@pixi/filter-alpha@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-alpha/-/filter-alpha-6.2.2.tgz#4c39d67deaf99d979019252ea6dab69d853bae84"
+  integrity sha512-CijLcgFdmivmSyZuM5Yyeo6R+PwalZp9OSoard1Oh5DBVvcRDn4m3cBM+nimR4YJbr0kiMbK4Ja8r+e2vwFVjA==
 
-"@pixi/filter-blur@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/filter-blur/-/filter-blur-6.2.1.tgz#c7a1360a3759b7507dff3caa5ef7aedc35d14fb9"
-  integrity sha512-5pIcdL4u5WAwGHsI8uNovb4iK50l+7Dz1ZIwuwbkGU8Xoti/dzeox4bgywnXPq+yN33/Ty0nwd7VYuHmaNl/Rw==
+"@pixi/filter-blur@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-blur/-/filter-blur-6.2.2.tgz#bc0f0d0fe2d7095d3fd8924dd013f154a7436e68"
+  integrity sha512-ApFqn2fMIipr3mRp/8dZ74qraGGzzPO/EzvltDqJLru9vGlbX6dKLXZ6w5H8D/uN6aQW1e4N1Nrtzk5mvJVQ3g==
 
-"@pixi/filter-color-matrix@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/filter-color-matrix/-/filter-color-matrix-6.2.1.tgz#ae3e34606f86ccb0e559fde663d8c17d34cc3ca9"
-  integrity sha512-f3yyaruhr8lAVv13YpMb5L4yolvuTygq05CvM3OIFK+dP5bYar2cajGc1Zu0bR3VGF03N8JeHxCUwfMwV7V7AA==
+"@pixi/filter-color-matrix@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-color-matrix/-/filter-color-matrix-6.2.2.tgz#9eb4c55ae37b2d6e221ef7bb1781c58fb33890ad"
+  integrity sha512-fQWbtKFWV29jKkq4d6TknEfQ5sF5OxcbJeZo0HJmgoV3FLZ0t21XE991CFI/TqDBo8U3wzUPZVbXxiFoDKmJ8w==
 
-"@pixi/filter-displacement@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/filter-displacement/-/filter-displacement-6.2.1.tgz#f178b54c870b75df4b0a8bc8b057e90fe4c7c500"
-  integrity sha512-o/MjC3tz1y3qZwf22FThGSqfn+zN5bMaBoXn+xSfCqC48thg9vgl2REq0jerDDMVSMW8vUvBUARfT+Wfm3SMDw==
+"@pixi/filter-displacement@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-displacement/-/filter-displacement-6.2.2.tgz#6eaa737b1c055c5daff77e384f6d2f728f2a93f3"
+  integrity sha512-cd9um4kNNIeqKA/wVZw+iha+XVbBOYBC8En5hk3ZXAIXxCHxOCz3KS+aOVejXH5EB/gMDPvNNwygn0SCpSGdKA==
 
-"@pixi/filter-fxaa@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/filter-fxaa/-/filter-fxaa-6.2.1.tgz#15c2c92e41e56336d28b53bd2845b96018189e7b"
-  integrity sha512-mIiAhBBDrOOPm1UF4isp7ti3d0y1y0xIZJnYbi15/Stmi1EQsMckDKg+V5uq9qbSm1jP3KoYq9dd7Oz/lr9srw==
+"@pixi/filter-fxaa@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-fxaa/-/filter-fxaa-6.2.2.tgz#fea85d68414f9ee7f417d7e54791ccbaccd861c4"
+  integrity sha512-e4qekMlsiEcjV0JRoqH3b34sk8yzT4jsROYPHzk0IiafE+nNNcF3vQmcmnfC0aGIyODzmNdzFLjlFkRRSviydA==
 
-"@pixi/filter-noise@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/filter-noise/-/filter-noise-6.2.1.tgz#aae2a66eced6179c0e883f6e5db546e786bdd154"
-  integrity sha512-jDIKo65p1VbqfUKuvb9UaNWaL4SRoc0SMYUwhSJcPjaWKv5bl7Ifqa6b/iQ31ZGHZGSot2ypwFeBiZLG1ndInQ==
+"@pixi/filter-noise@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-noise/-/filter-noise-6.2.2.tgz#a4617a279e968628d7e088b36bf28c8c7cf85fb9"
+  integrity sha512-Jp4L6winS6ZGKpp76x3JyfEWnUMY44fQ90Ts3R3vKkZZFNDd3T4uisZ7YwvDKOhmSo5hY3lQkXaCg/YO5feXbw==
 
-"@pixi/graphics@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/graphics/-/graphics-6.2.1.tgz#ded5248b7a7e64f0f225008493fdc126ef63a928"
-  integrity sha512-/MQREXYx+/glVAQLyNTLnd9+C1Bktm/F1XDzu5swDQSRH2Fo1rCh3mPw0dmJmrWrOOpBTO2+W7Kgm6NkENw9qA==
+"@pixi/graphics@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/graphics/-/graphics-6.2.2.tgz#bffa1b6ab75a2c5ca54a83444e5cafe6e68dd7c7"
+  integrity sha512-mQyd6ef6/EF5nt7M1OObBEb9FCXxIP6AT30H01Z2wnnCgu4qj8MHrJxTkQxSHynQ+eVVPswzpVizUQZHlIYZNw==
 
-"@pixi/interaction@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/interaction/-/interaction-6.2.1.tgz#2d3ef012a15aff8af7c5b5c1d1983778983147b4"
-  integrity sha512-WsubcDQt447+JtDhDHNfkmkEah4Ytry5WYIKbUZSvBdIc9LVXHPLQ+gM4mKkprEV8ZsQb6H/NbmtIKxjxHGYvw==
+"@pixi/interaction@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/interaction/-/interaction-6.2.2.tgz#31abd2ed0b810570ff487dd7595b755b76f5a3ba"
+  integrity sha512-gpNLCPc+j+RZSZqbKbzVRf4fSlOlYm0xqUVn6JtNH1kc+d9AV7Nmw9but4osP/eodDWsWPQ+7sPKClHY36bKRA==
 
-"@pixi/loaders@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/loaders/-/loaders-6.2.1.tgz#ce956e343a9684d3789886fe06ec4610bda5c002"
-  integrity sha512-UB1uYb3HL4uN1q+w916DNLIZzz7gkg3p4QQRmBXq08Dnj8DWCghPRAfTGfCu3ORqYqEwSaZ+ulLT+SRfHryvyQ==
+"@pixi/loaders@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/loaders/-/loaders-6.2.2.tgz#b4fdf00f193733c14d499d4ae74fedc9063a6270"
+  integrity sha512-jwFM59GeMQpzuniw5PlC7kCoXZEaKrw31/ecR1sXKWDtHRyMtvXTuf+R+tSol/1ISQ55c0JBTuUbLPwp7hPvFQ==
 
-"@pixi/math@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/math/-/math-6.2.1.tgz#86a4c1d25ea6c03f9b4d3ec33bc925151f61b7e5"
-  integrity sha512-ejAHHbJSRtAhpFVFOQ4niavCDkjISWBxjFQoqznManDZKXBH0vf8EQBWSth5Cp9wXXAG0mAt4gzlwYXEf7Axkg==
+"@pixi/math@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/math/-/math-6.2.2.tgz#dfbeeb03de765fa6e1fcfbd2058ed0037d945a86"
+  integrity sha512-TtsaooRRMc/WAZ4LKUDhP/d14BZElLjRNa2gopwTKUtrDa1KvzAMr8WJ8P+gaXl4DJ8B/MlgESdPhRUqVSUw0A==
 
-"@pixi/mesh-extras@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/mesh-extras/-/mesh-extras-6.2.1.tgz#5fa199f78f0f04fabde789418d967d6780bb7008"
-  integrity sha512-mgIRiW4W5aOI1lDawNBTNsDZAy+qBGwwBgYsvRqjqOK6cxQ2pnDSEvphK3k2k+Qk2zUBFzqIxSWcG9EWnDQf2Q==
+"@pixi/mesh-extras@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/mesh-extras/-/mesh-extras-6.2.2.tgz#127280bcb686896b62a9b26f69681a60ecc9f3c2"
+  integrity sha512-HFYWhWcV6gY7VYnMhz9OSEN14PPfVqLzWnglbegGEMqCbY/ZGsD8X99x/HLGQGd6L4FFto382q0Fj1xu+y/brg==
 
-"@pixi/mesh@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/mesh/-/mesh-6.2.1.tgz#d575532e88a4619aede866a4befd0732c21fe914"
-  integrity sha512-ekLhRxk6g8sVwrEj3xtVNmyCoCgKSIlqVYL26a2QWYAllWeP1FZiCmBJGk6FAXlIrzG76+aymiUVH35pD1gZvw==
+"@pixi/mesh@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/mesh/-/mesh-6.2.2.tgz#f301bbf888ca36994b8edb30a590fbe4a035dd6f"
+  integrity sha512-CsKFgTu2MP756sHeoCr9s4tHy2VmnDZPnvZ0ThV8QMnb5w3Z2qRDKlXSSIdNaQOxoAPKkqxIu0JbLK8kyX0oqw==
 
-"@pixi/mixin-cache-as-bitmap@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.2.1.tgz#92a7a87166bcbd252ac8048d17239992204fc969"
-  integrity sha512-+KsDxCrlvWK2S4ExaKMWFp5RPiFxbBZS2rQ3yrA5GTUC4uZUWm3QptVjHmWb1kjgD5l/QOGF40ZFTu8FfqXtlg==
+"@pixi/mixin-cache-as-bitmap@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.2.2.tgz#4c0cdddeba91578f6e58a48df7c27743bcfc8f84"
+  integrity sha512-t3jZKGa/qoRMetMWmGkXz8Kp1Uzmb+2y4/adqu+RdIeG3D1oItuGux+R36ZQO6dVRv3R8s2/Dex0aACek171zw==
 
-"@pixi/mixin-get-child-by-name@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.2.1.tgz#4e202d787268c2b405bee3a973d73f7f1c1880a1"
-  integrity sha512-Osrydgec/Zqu1rxz3wJlNH8qe3a8qyOC6dvzS0QlU6gIe7EUfqFSKSCsnht8zDFTNOBPL/hzG1JKDWTOBqRj8g==
+"@pixi/mixin-get-child-by-name@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.2.2.tgz#154d8f0d8324d0cbd84a695babd960a0c35b6c10"
+  integrity sha512-BBrniLAkzDex4HyvVdE/DjphzQu4pZ8Nc5aDRIbiS1s283/IXr2oTcoaW23kCjhX0xgu++XcJQQMMyv3mlblZQ==
 
-"@pixi/mixin-get-global-position@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.2.1.tgz#ca3ebf24b24b3189b2ecc5e2bd09e1582e97e397"
-  integrity sha512-3W5u3b5A4U6glUMPal1/8vug5gs5CIlum9K30VnNQ2Q2bC4mZ6CEBHVIN6pG7ekg3E7xbLwp/WlZM9wZ1yr7ng==
+"@pixi/mixin-get-global-position@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.2.2.tgz#361c4d9889a0b9a724e0cc92fb01d7705b1edb3e"
+  integrity sha512-Rz7DHn6koYFEeVG36rKiMwoTD+elJKqwQ24HHw0BAKz1VwGagBi0ZTcJ+nWplBOrw6ZPKfdOBwGQLXD7ODg8lQ==
 
-"@pixi/particle-container@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/particle-container/-/particle-container-6.2.1.tgz#ae227fb6f7de9b9275b78a17d634887c37724e48"
-  integrity sha512-uk8erald8eGiucE0336YTIOS4e1HkSYc8ZYkJnCfxEPcOSMyPEmInI+kWtq0IHa1icX9G4zZRh9rj3vCfCLY+A==
+"@pixi/particle-container@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/particle-container/-/particle-container-6.2.2.tgz#ff6b4c5da58b052b177a8504ab2a3a53851c460c"
+  integrity sha512-DYbSCcUiVLeM4sKZkzAp3F6dz3idyP1jecxbFqNmRjWRyMv7uXIO42rxGJMrd6BzA5j7DkywI3X0SqhhSZP7Ag==
 
-"@pixi/polyfill@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/polyfill/-/polyfill-6.2.1.tgz#06d171fc4d06cfcbfb136726137c9c98cda9a0da"
-  integrity sha512-t7xHLTq3L1FBWT65LR+L1rTjqFq6yDAS+07cG4GCp1TrjcBGV4RGNuB4VhlQOsxVJIhzzEry+3TQt6/EenQ5TQ==
+"@pixi/polyfill@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/polyfill/-/polyfill-6.2.2.tgz#18c0a2e7273fcd505f78aa08ee4c10010dca3314"
+  integrity sha512-Fd5KnjrqG9Vwgl9sDfPvNeqW3/d+hG9Du7H3y5PmItBnu9wXldTtA+I5D0BLsL/wjjjCQLbPVFKwCJj511XfBw==
   dependencies:
     object-assign "^4.1.1"
     promise-polyfill "^8.2.0"
 
-"@pixi/prepare@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/prepare/-/prepare-6.2.1.tgz#11dbece209abfba0ff9acd29801954633dfd1432"
-  integrity sha512-SsNnZilq0gikrO/LjL+gEaUzmrFpkNeROgyfT6Pa3l2HWqG4eoU+iPxSH3f0WshYyZPLF793ryFut9tSJKLCSw==
+"@pixi/prepare@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/prepare/-/prepare-6.2.2.tgz#7dd53bc2415d371113806700c103e074615f14a8"
+  integrity sha512-kJojn/6zEcao+XQyU+zWkBmQr0Tgeju3F9JYBpPQ8MKIUJYvDQDtRxYo9A6Xzxk8FJ373s2Ext/OelX2FcR3HQ==
 
-"@pixi/runner@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/runner/-/runner-6.2.1.tgz#ee2bc3554b7e77647139728cb17f1833c84b588c"
-  integrity sha512-m3dB5b212WJ3wa7QGBY27NckHtQu1TR2FwtEeMyL0g0tSfCf1ve0Pegf39q9PQ4D1/C1j0n58JuKBqSf9oH66Q==
+"@pixi/runner@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/runner/-/runner-6.2.2.tgz#ac253ee250198437b7a7182078a90e1e752f8ada"
+  integrity sha512-q7bc6Eu2XplGzCQBOhbv32P0z48ixW/Su6epT9IOfDi2iTiPjB5Sxp9e+DZDFIzvkfLzgr67Ddy51YMvOp5sQg==
 
-"@pixi/settings@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/settings/-/settings-6.2.1.tgz#b13bb809fb5eaa8e1289f654a5c0a7080f195aa1"
-  integrity sha512-GVgLgTdEMZDSEyly+yX+49MhVzEiSyJCHItAurLUVGLvi443AcRuK57mYVNDdTfOn2VRIvwW7FNgwdrzq58WWQ==
+"@pixi/settings@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/settings/-/settings-6.2.2.tgz#1984a9a233b5e78c3cf564fed5a2cde3012b754c"
+  integrity sha512-eQv0ykSwnJUd/LF4MuaFoL+eBNG+EUPAVfsnlsez/Y09aqwIzJyAjRx+uGp9adQ3XHXwYt2l2wINn+foF1y/8A==
   dependencies:
     ismobilejs "^1.1.0"
 
-"@pixi/sprite-animated@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/sprite-animated/-/sprite-animated-6.2.1.tgz#29e81d86e282966bebde8e686012e4dc31f1b236"
-  integrity sha512-puJtJFcHgyYuWf4EdFOVMFimtQsTxskNwI/CMw5HQBuz8dPB3aHensVGyv7mPzr0zpl7Ruzb6l+F5Y/G6jbugg==
+"@pixi/sprite-animated@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/sprite-animated/-/sprite-animated-6.2.2.tgz#8006a943834fbb5059800e0b57b08c890524a264"
+  integrity sha512-MNkVIuC06aXn8bgfWyqQE8vmclCVLgmHB//hssr/1IFCVmnEEYZLyeWErkIA87grY3iV7tGOILEYSa3pod4XEg==
 
-"@pixi/sprite-tiling@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/sprite-tiling/-/sprite-tiling-6.2.1.tgz#6c387de11bc75c3e38d459dfa3489fb228fcbc6f"
-  integrity sha512-YPPqRRBp7JvQq1MjGU7IaKL+7WNeSsHNjUlQfawPR3XvNFLKb7zks1DvR09AziMm8u4h6/wfejFuRycqg/3gvQ==
+"@pixi/sprite-tiling@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/sprite-tiling/-/sprite-tiling-6.2.2.tgz#2447fd92af3e9ddf2bdaa143018eb4f721fc0714"
+  integrity sha512-HQ9RVObmwyPq+PM2wm2UEIMdsvWg96ymSz0NOh9bOfMSme18vSWv0Rbidv/FziQT8x6MpoLpYke0DYMGtbu0tA==
 
-"@pixi/sprite@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/sprite/-/sprite-6.2.1.tgz#6c16afb64e169d90ec214dfbae726870a3eb4dc1"
-  integrity sha512-NV4mS3vUcVgi9qKtY3SH/tf5goinCAJId3bmj76MAlBDNaE8wyu7bEcWLQFIHC59zxJCOd5D/iOmDqVKiOu4Dw==
+"@pixi/sprite@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/sprite/-/sprite-6.2.2.tgz#a699e95f3da0f290e798a076ff30c4ec0cc6f263"
+  integrity sha512-Imr+sJWFh5GtarW3FBBUzedSexfijg7OL0A6qwMDHA011gjyVeRZ15uXP8fgIwUoHoMLsU6xk85jcucM9RfWuw==
 
-"@pixi/spritesheet@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/spritesheet/-/spritesheet-6.2.1.tgz#f39d1ab22ab41f7b3ae7eedaa1d947dc81071ba7"
-  integrity sha512-mCJn3044/VX2Z0nGr+5brWR2F9akKzKAI4OBqmQU4mfiy7Q4+MM0Fgk9vHc7wKCuhUz//U7SmK6CdCqZknVaAA==
+"@pixi/spritesheet@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/spritesheet/-/spritesheet-6.2.2.tgz#84013fff2f7a6b50f1403484d7cb445a4510198c"
+  integrity sha512-TZodC/pf+CW/8kZN+RPzObXWSPgYv1pp+foUnOHb7w8AyFnMljeqBPiUfLQaMzw91TI9AHLihoeeofqZ4wMpww==
 
-"@pixi/text-bitmap@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/text-bitmap/-/text-bitmap-6.2.1.tgz#f3c86350ee7029107130c2ba6f8d66999710f22e"
-  integrity sha512-fbOz1aTyXUu0+fuWVnL6eGu5WhpQlF83GM8CKBo2j4NqhxYnkIn4r5g2QSYXVAZ5PSeUjGO0o7lUKxZN0Wq2gg==
+"@pixi/text-bitmap@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/text-bitmap/-/text-bitmap-6.2.2.tgz#26f2838a06edc2e17659d6e02d4244b714e4b61d"
+  integrity sha512-pJZM0o68n6cUFUdolvpuuloMccdQqvTc3CLzhLu9xW9HLx7NeFjZEQWTGQea8GXsGa1RhvlMd9x3AiVSNMI2FA==
 
-"@pixi/text@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/text/-/text-6.2.1.tgz#1fdd68003d05db2102d6c11740c624d94fa9829d"
-  integrity sha512-vTwXm6RVcSa4RXlqknxf1y7Q35fyOWIlERz3eb6STcoGFOwbXSjdIsAkamjKzbasfF0rSe910QHYxs2XWJ6ozA==
+"@pixi/text@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/text/-/text-6.2.2.tgz#bf4bd0e9fdf9041e3516bbaae2094f6ab8b4ee26"
+  integrity sha512-Hi6MO/QhllZ4IWkr7MBzImzHB88XXKlF5E9xt1vUBhdZb3KsQD+cPx+bNCFWn6ZMWDmOloJekzRkkSl3KrfBSw==
 
-"@pixi/ticker@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/ticker/-/ticker-6.2.1.tgz#55e55cb1135ca5630f3b2c402ad7e8ab2fb1fb4e"
-  integrity sha512-J9UCTIJswM7HO76CtBpJAB+EMBxElmJ+JV9uTUQBGZVc6cmQI9JPPx1QcDWVkuF4qv1Keeh0Tjhnq8Sjc701AA==
+"@pixi/ticker@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/ticker/-/ticker-6.2.2.tgz#3170ce5f44c56ac1bdb1a66a1f393d023c9cbb4e"
+  integrity sha512-tF3cRtcYnj3U3HFQ0IJKvAxFU1YUM96T0p8Qh478xZhvGxYGnjrQDPmjXePb4NocAdG5adb6//2uvQOd7o4rHg==
 
-"@pixi/utils@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@pixi/utils/-/utils-6.2.1.tgz#6bc987b170e8452c2df79ec9abac8915722dc4ff"
-  integrity sha512-aLOIzDZ6ccJ/DfGs9vldjWXn3RHpOMR26Bkr3aeynn/p1rdY3n2dzC8oKWwVb3gPQWmsEZJa8QuLvOiIwHqAJg==
+"@pixi/utils@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@pixi/utils/-/utils-6.2.2.tgz#cf292ceb494992e7974982043b214617615ce335"
+  integrity sha512-rpS6QolFuRmm/QcKm5PYHOCkX6okl9a00u2osaMbmPP+l7XLATTxSsFhw64UbSNR+zmzsrhreRFBVFn3tf8K6w==
   dependencies:
     "@types/earcut" "^2.1.0"
     earcut "^2.2.2"
@@ -22096,46 +22096,46 @@ pixi-viewport@^4.34.4:
   resolved "https://registry.yarnpkg.com/pixi-viewport/-/pixi-viewport-4.34.4.tgz#78d575235225d852e5017e89da7cc939ec50a9f8"
   integrity sha512-JARPbHRxmbiedj2qc/kjwd0rKIplKoRcLIDjO9DAMtjXzAlVWAdkwLxvY7g2EJBCHqNqxrEQy9ssye1DM4XRKg==
 
-pixi.js@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/pixi.js/-/pixi.js-6.2.1.tgz#97361731cf20dfa9a403fae8f26f8a69c8a4dcd0"
-  integrity sha512-oZaa4QAkzcYnXRBH3O8u2LuUVO6gTPKSZijZIYhv6+EDBULZvPxlOZf7jFQNpXVgKAXhptQmOytO1LnWMuK2Sg==
+pixi.js@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/pixi.js/-/pixi.js-6.2.2.tgz#bc8319f007e48c0d5190b32b3e4f1d5bee0677e4"
+  integrity sha512-/xCnJUsWTZuacR6JYTnRbUb+5grzlqpp2O1Ub7bCZCE3FApTCs7nMNYeLfdeP+np/MlGaM+SsPh2cXcafR3OZw==
   dependencies:
-    "@pixi/accessibility" "6.2.1"
-    "@pixi/app" "6.2.1"
-    "@pixi/compressed-textures" "6.2.1"
-    "@pixi/constants" "6.2.1"
-    "@pixi/core" "6.2.1"
-    "@pixi/display" "6.2.1"
-    "@pixi/extract" "6.2.1"
-    "@pixi/filter-alpha" "6.2.1"
-    "@pixi/filter-blur" "6.2.1"
-    "@pixi/filter-color-matrix" "6.2.1"
-    "@pixi/filter-displacement" "6.2.1"
-    "@pixi/filter-fxaa" "6.2.1"
-    "@pixi/filter-noise" "6.2.1"
-    "@pixi/graphics" "6.2.1"
-    "@pixi/interaction" "6.2.1"
-    "@pixi/loaders" "6.2.1"
-    "@pixi/math" "6.2.1"
-    "@pixi/mesh" "6.2.1"
-    "@pixi/mesh-extras" "6.2.1"
-    "@pixi/mixin-cache-as-bitmap" "6.2.1"
-    "@pixi/mixin-get-child-by-name" "6.2.1"
-    "@pixi/mixin-get-global-position" "6.2.1"
-    "@pixi/particle-container" "6.2.1"
-    "@pixi/polyfill" "6.2.1"
-    "@pixi/prepare" "6.2.1"
-    "@pixi/runner" "6.2.1"
-    "@pixi/settings" "6.2.1"
-    "@pixi/sprite" "6.2.1"
-    "@pixi/sprite-animated" "6.2.1"
-    "@pixi/sprite-tiling" "6.2.1"
-    "@pixi/spritesheet" "6.2.1"
-    "@pixi/text" "6.2.1"
-    "@pixi/text-bitmap" "6.2.1"
-    "@pixi/ticker" "6.2.1"
-    "@pixi/utils" "6.2.1"
+    "@pixi/accessibility" "6.2.2"
+    "@pixi/app" "6.2.2"
+    "@pixi/compressed-textures" "6.2.2"
+    "@pixi/constants" "6.2.2"
+    "@pixi/core" "6.2.2"
+    "@pixi/display" "6.2.2"
+    "@pixi/extract" "6.2.2"
+    "@pixi/filter-alpha" "6.2.2"
+    "@pixi/filter-blur" "6.2.2"
+    "@pixi/filter-color-matrix" "6.2.2"
+    "@pixi/filter-displacement" "6.2.2"
+    "@pixi/filter-fxaa" "6.2.2"
+    "@pixi/filter-noise" "6.2.2"
+    "@pixi/graphics" "6.2.2"
+    "@pixi/interaction" "6.2.2"
+    "@pixi/loaders" "6.2.2"
+    "@pixi/math" "6.2.2"
+    "@pixi/mesh" "6.2.2"
+    "@pixi/mesh-extras" "6.2.2"
+    "@pixi/mixin-cache-as-bitmap" "6.2.2"
+    "@pixi/mixin-get-child-by-name" "6.2.2"
+    "@pixi/mixin-get-global-position" "6.2.2"
+    "@pixi/particle-container" "6.2.2"
+    "@pixi/polyfill" "6.2.2"
+    "@pixi/prepare" "6.2.2"
+    "@pixi/runner" "6.2.2"
+    "@pixi/settings" "6.2.2"
+    "@pixi/sprite" "6.2.2"
+    "@pixi/sprite-animated" "6.2.2"
+    "@pixi/sprite-tiling" "6.2.2"
+    "@pixi/spritesheet" "6.2.2"
+    "@pixi/text" "6.2.2"
+    "@pixi/text-bitmap" "6.2.2"
+    "@pixi/ticker" "6.2.2"
+    "@pixi/utils" "6.2.2"
 
 pkg-dir@4.2.0, pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
## Summary
Use the `@timestamp` field instead of `TimeStamp` and use the right search in topN queries, with regards to the data model updated with https://github.com/elastic/prodfiler/pull/2026/files

For the review: the yarn.lock and package.json files are not strictly related to this PR, but help in building and using the project.
@jbcrail and I decided it was handy to commit them despite the discussion going on with other teams: including Pixi.js as a dependency or not.

## Additional context
The UI has hardcoded the ProjectID=5 in the query string passed to Kibana; for this reason, only data set with such field value will be queried in the topN views.

### How to test this PR
* be sure to have built the `pf-elastic-collector` from the above PR
* re-create the indices and run the collector
* run the host-agent using `PRODFILER_PROJECT_ID=5`
* start kibana (`yarn start` from this PR)
* browse the Prodfiler app




