### PR TITLE
mappings: rename TraceHash to StackTraceID

### DIFF
--- a/src/plugins/profiling/common/index.ts
+++ b/src/plugins/profiling/common/index.ts
@@ -5,6 +5,8 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+import {KibanaRequest} from 'kibana/server';
+
 export const PLUGIN_ID = 'profiling';
 export const PLUGIN_NAME = 'profiling';
 
@@ -84,4 +86,10 @@ export function groupSamplesByCategory(samples) {
     value.push([v.x, v.y]);
   }
   return series;
+}
+
+export function timeRangeFromRequest(request: any): [number, number] {
+  const timeFrom = parseInt(request.query.timeFrom!, 10);
+  const timeTo = parseInt(request.query.timeTo!, 10);
+  return [timeFrom, timeTo];
 }

--- a/src/plugins/profiling/server/routes/index.ts
+++ b/src/plugins/profiling/server/routes/index.ts
@@ -41,7 +41,7 @@ export function getDocID(hi: bigint, lo: bigint) {
   return btoa(bin.join('')).replace('+', '-').replace('/', '_');
 }
 
-export function getOtherDocID(hi: bigint, lo: bigint, other: bigint) {
+export function getOtherDocID(hi: bigint, lo: bigint, other: bigint): string {
   let hex = hi.toString(16);
   const hexLo = lo.toString(16);
   const hexOther = other.toString(16);

--- a/src/plugins/profiling/server/routes/load_flameChartElastic.ts
+++ b/src/plugins/profiling/server/routes/load_flameChartElastic.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import type { DataRequestHandlerContext } from '../../../data/server';
 import type { IRouter } from '../../../../core/server';
-import { getLocalRoutePaths } from '../../common';
+import { getLocalRoutePaths, timeRangeFromRequest } from '../../common';
 import { mapFlamechart } from './mappings';
 
 export function registerFlameChartElasticRoute(router: IRouter<DataRequestHandlerContext>) {
@@ -26,10 +26,8 @@ export function registerFlameChartElasticRoute(router: IRouter<DataRequestHandle
       },
     },
    async (ctx, request, response) => {
-      const timeFrom = parseInt(request.query.timeFrom);
-      const timeTo = parseInt(request.query.timeTo);
-      const seconds = timeTo - timeFrom;
-      const src = await import(`../fixtures/flamechart_${seconds}`);
+      const [timeFrom, timeTo] = timeRangeFromRequest(request);
+      const src = await import(`../fixtures/flamechart_${timeTo - timeFrom}`);
       delete src.default;
       return response.ok({ body: mapFlamechart(src) });
     }

--- a/src/plugins/profiling/server/routes/load_flameChartPixi.ts
+++ b/src/plugins/profiling/server/routes/load_flameChartPixi.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import type { DataRequestHandlerContext } from '../../../data/server';
 import type { IRouter } from '../../../../core/server';
-import { getLocalRoutePaths } from '../../common';
+import { getLocalRoutePaths, timeRangeFromRequest } from '../../common';
 
 export function registerFlameChartPixiRoute(router: IRouter<DataRequestHandlerContext>) {
   const paths = getLocalRoutePaths();
@@ -24,11 +24,9 @@ export function registerFlameChartPixiRoute(router: IRouter<DataRequestHandlerCo
         }),
       },
     },
-   async (ctx, request, response) => {
-      const timeFrom = parseInt(request.query.timeFrom);
-      const timeTo = parseInt(request.query.timeTo);
-      const seconds = timeTo - timeFrom;
-      const src = await import(`../fixtures/flamechart_${seconds}`);
+    async (ctx, request, response) => {
+      const [timeFrom, timeTo] = timeRangeFromRequest(request);
+      const src = await import(`../fixtures/flamechart_${timeTo - timeFrom}`);
       delete src.default;
       return response.ok({ body: src });
     }

--- a/src/plugins/profiling/server/routes/load_topNContainers.ts
+++ b/src/plugins/profiling/server/routes/load_topNContainers.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import type { DataRequestHandlerContext } from '../../../data/server';
 import type { IRouter } from '../../../../core/server';
-import { getLocalRoutePaths } from '../../common';
+import { getLocalRoutePaths, timeRangeFromRequest } from '../../common';
 
 export function registerTraceEventsTopNContainersRoute(router: IRouter<DataRequestHandlerContext>) {
   const paths = getLocalRoutePaths();
@@ -24,11 +24,9 @@ export function registerTraceEventsTopNContainersRoute(router: IRouter<DataReque
         }),
       },
     },
-   async (ctx, request, response) => {
-      const timeFrom = parseInt(request.query.timeFrom);
-      const timeTo = parseInt(request.query.timeTo);
-      const seconds = timeTo - timeFrom;
-      const src = await import(`../fixtures/containers_${seconds}`);
+    async (ctx, request, response) => {
+      const [timeFrom, timeTo] = timeRangeFromRequest(request);
+      const src = await import(`../fixtures/containers_${timeTo - timeFrom}`);
       delete src.default;
       return response.ok({ body: src });
     }

--- a/src/plugins/profiling/server/routes/load_topNDeployments.ts
+++ b/src/plugins/profiling/server/routes/load_topNDeployments.ts
@@ -8,9 +8,11 @@
 import { schema } from '@kbn/config-schema';
 import type { DataRequestHandlerContext } from '../../../data/server';
 import type { IRouter } from '../../../../core/server';
-import { getLocalRoutePaths } from '../../common';
+import { getLocalRoutePaths, timeRangeFromRequest } from '../../common';
 
-export function registerTraceEventsTopNDeploymentsRoute(router: IRouter<DataRequestHandlerContext>) {
+export function registerTraceEventsTopNDeploymentsRoute(
+  router: IRouter<DataRequestHandlerContext>
+) {
   const paths = getLocalRoutePaths();
   router.get(
     {
@@ -24,11 +26,9 @@ export function registerTraceEventsTopNDeploymentsRoute(router: IRouter<DataRequ
         }),
       },
     },
-   async (ctx, request, response) => {
-      const timeFrom = parseInt(request.query.timeFrom);
-      const timeTo = parseInt(request.query.timeTo);
-      const seconds = timeTo - timeFrom;
-      const src = await import(`../fixtures/pods_${seconds}`);
+    async (ctx, request, response) => {
+      const [timeFrom, timeTo] = timeRangeFromRequest(request);
+      const src = await import(`../fixtures/pods_${timeTo - timeFrom}`);
       delete src.default;
       return response.ok({ body: src });
     }

--- a/src/plugins/profiling/server/routes/load_topNHosts.ts
+++ b/src/plugins/profiling/server/routes/load_topNHosts.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import type { DataRequestHandlerContext } from '../../../data/server';
 import type { IRouter } from '../../../../core/server';
-import { getLocalRoutePaths } from '../../common';
+import {getLocalRoutePaths, timeRangeFromRequest} from '../../common';
 
 export function registerTraceEventsTopNHostsRoute(router: IRouter<DataRequestHandlerContext>) {
   const paths = getLocalRoutePaths();
@@ -24,11 +24,9 @@ export function registerTraceEventsTopNHostsRoute(router: IRouter<DataRequestHan
         }),
       },
     },
-   async (ctx, request, response) => {
-      const timeFrom = parseInt(request.query.timeFrom);
-      const timeTo = parseInt(request.query.timeTo);
-      const seconds = timeTo - timeFrom;
-      const src = await import(`../fixtures/hosts_${seconds}`);
+    async (ctx, request, response) => {
+      const [timeFrom, timeTo] = timeRangeFromRequest(request);
+      const src = await import(`../fixtures/hosts_${timeTo - timeFrom}`);
       delete src.default;
       return response.ok({ body: src });
     }

--- a/src/plugins/profiling/server/routes/load_topNStackTraces.ts
+++ b/src/plugins/profiling/server/routes/load_topNStackTraces.ts
@@ -25,7 +25,9 @@ function transformFlamechart(src) {
   return obj;
 }
 
-export function registerTraceEventsTopNStackTracesRoute(router: IRouter<DataRequestHandlerContext>) {
+export function registerTraceEventsTopNStackTracesRoute(
+  router: IRouter<DataRequestHandlerContext>
+) {
   const paths = getLocalRoutePaths();
   router.get(
     {
@@ -39,9 +41,9 @@ export function registerTraceEventsTopNStackTracesRoute(router: IRouter<DataRequ
         }),
       },
     },
-   async (ctx, request, response) => {
-      const timeFrom = parseInt(request.query.timeFrom);
-      const timeTo = parseInt(request.query.timeTo);
+    async (ctx, request, response) => {
+      const timeFrom = parseInt(request.query.timeFrom, 10);
+      const timeTo = parseInt(request.query.timeTo, 10);
       const seconds = timeTo - timeFrom;
       const src = await import(`../fixtures/traces_${seconds}`);
       delete src.default;

--- a/src/plugins/profiling/server/routes/load_topNStackTraces.ts
+++ b/src/plugins/profiling/server/routes/load_topNStackTraces.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import type { DataRequestHandlerContext } from '../../../data/server';
 import type { IRouter } from '../../../../core/server';
-import { getLocalRoutePaths } from '../../common';
+import { getLocalRoutePaths, timeRangeFromRequest } from '../../common';
 
 function transformFlamechart(src) {
   const obj = {
@@ -42,10 +42,8 @@ export function registerTraceEventsTopNStackTracesRoute(
       },
     },
     async (ctx, request, response) => {
-      const timeFrom = parseInt(request.query.timeFrom, 10);
-      const timeTo = parseInt(request.query.timeTo, 10);
-      const seconds = timeTo - timeFrom;
-      const src = await import(`../fixtures/traces_${seconds}`);
+      const [timeFrom, timeTo] = timeRangeFromRequest(request);
+      const src = await import(`../fixtures/traces_${timeTo - timeFrom}`);
       delete src.default;
       return response.ok({ body: transformFlamechart(src) });
     }

--- a/src/plugins/profiling/server/routes/load_topNThreads.ts
+++ b/src/plugins/profiling/server/routes/load_topNThreads.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import type { DataRequestHandlerContext } from '../../../data/server';
 import type { IRouter } from '../../../../core/server';
-import { getLocalRoutePaths } from '../../common';
+import { getLocalRoutePaths, timeRangeFromRequest } from '../../common';
 
 export function registerTraceEventsTopNThreadsRoute(router: IRouter<DataRequestHandlerContext>) {
   const paths = getLocalRoutePaths();
@@ -24,11 +24,9 @@ export function registerTraceEventsTopNThreadsRoute(router: IRouter<DataRequestH
         }),
       },
     },
-   async (ctx, request, response) => {
-      const timeFrom = parseInt(request.query.timeFrom);
-      const timeTo = parseInt(request.query.timeTo);
-      const seconds = timeTo - timeFrom;
-      const src = await import(`../fixtures/threads_${seconds}`);
+    async (ctx, request, response) => {
+      const [timeFrom, timeTo] = timeRangeFromRequest(request);
+      const src = await import(`../fixtures/threads_${timeTo - timeFrom}`);
       delete src.default;
       return response.ok({ body: src });
     }

--- a/src/plugins/profiling/server/routes/search_flameChart.ts
+++ b/src/plugins/profiling/server/routes/search_flameChart.ts
@@ -74,7 +74,7 @@ export function registerFlameChartSearchRoute(router: IRouter<DataRequestHandler
                       aggs: {
                         group_by: {
                           terms: {
-                            field: 'TraceHash',
+                            field: 'StackTraceID',
                             size: 20000,
                           },
                         },

--- a/src/plugins/profiling/server/routes/search_topN.ts
+++ b/src/plugins/profiling/server/routes/search_topN.ts
@@ -96,7 +96,7 @@ export function queryTopNCommon(
           )
           .toPromise();
 
-        if (searchField === 'TraceHash') {
+        if (searchField === 'StackTraceID') {
           const docIDs: string[] = [];
           resTopNStackTraces.rawResponse.aggregations.histogram.buckets.forEach((timeInterval) => {
             timeInterval.group_by.buckets.forEach((stackTraceItem: any) => {

--- a/src/plugins/profiling/server/routes/search_topNStackTraces.ts
+++ b/src/plugins/profiling/server/routes/search_topNStackTraces.ts
@@ -14,5 +14,5 @@ export function registerTraceEventsTopNStackTracesSearchRoute(
   router: IRouter<DataRequestHandlerContext>
 ) {
   const paths = getRemoteRoutePaths();
-  return queryTopNCommon(router, paths.TopNTraces, 'TraceHash');
+  return queryTopNCommon(router, paths.TopNTraces, 'StackTraceID');
 }


### PR DESCRIPTION
## Summary
In prodfiler PR https://github.com/elastic/prodfiler/pull/2026 we change the mapping of field `TraceHash` to `StackTraceID` so we have to do the same here.

There are also a couple of linting fixes.