### PR TITLE
TopN view: fix host panel

### DIFF
--- a/src/plugins/profiling/public/services.ts
+++ b/src/plugins/profiling/public/services.ts
@@ -20,8 +20,8 @@ function getFetchQuery(seconds: string): HttpFetchQuery {
   return {
     index: 'profiling-events',
     projectID: 5,
-    timeFrom: unixTime - parseInt(seconds),
-    timeTo: unixTime
+    timeFrom: unixTime - parseInt(seconds, 10),
+    timeTo: unixTime,
   } as HttpFetchQuery;
 }
 
@@ -33,11 +33,7 @@ export function getServices(core: CoreStart): Services {
     fetchTopN: async (type: string, seconds: string) => {
       try {
         const query = getFetchQuery(seconds);
-        const response = await core.http.get(
-          `${paths.TopN}/${type}`,
-          { query }
-        );
-        return response;
+        return await core.http.get(`${paths.TopN}/${type}`, { query });
       } catch (e) {
         return e;
       }
@@ -46,11 +42,7 @@ export function getServices(core: CoreStart): Services {
     fetchElasticFlamechart: async (seconds: string) => {
       try {
         const query = getFetchQuery(seconds);
-        const response = await core.http.get(
-          paths.FlamechartElastic,
-          { query }
-        );
-        return response;
+        return await core.http.get(paths.FlamechartElastic, { query });
       } catch (e) {
         return e;
       }
@@ -59,11 +51,7 @@ export function getServices(core: CoreStart): Services {
     fetchPixiFlamechart: async (seconds: string) => {
       try {
         const query = getFetchQuery(seconds);
-        const response = await core.http.get(
-          paths.FlamechartPixi,
-          { query }
-        );
-        return response;
+        return await core.http.get(paths.FlamechartPixi, { query });
       } catch (e) {
         return e;
       }

--- a/src/plugins/profiling/server/routes/search_topNHosts.ts
+++ b/src/plugins/profiling/server/routes/search_topNHosts.ts
@@ -8,11 +8,11 @@
 import type { DataRequestHandlerContext } from '../../../data/server';
 import type { IRouter } from '../../../../core/server';
 import { getRemoteRoutePaths } from '../../common';
-import { queryTopNCommon } from "./search_topN";
+import { queryTopNCommon } from './search_topN';
 
 export function registerTraceEventsTopNHostsSearchRoute(
   router: IRouter<DataRequestHandlerContext>
 ) {
   const paths = getRemoteRoutePaths();
-  return queryTopNCommon(router, paths.TopNHosts, 'HostName');
+  return queryTopNCommon(router, paths.TopNHosts, 'HostID');
 }


### PR DESCRIPTION
## Summary

The TopN view "Hosts" section currently does not render any hosts because the name of the field queried in the mapping is different.
We fix this in this PR, and apply some further linting fixes.