### PR TITLE
Render Elastic flamegraph correctly

### DIFF
--- a/src/plugins/profiling/server/routes/flamegraph.ts
+++ b/src/plugins/profiling/server/routes/flamegraph.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export class FlameGraph {
+  constructor(events, totalEvents, stackTraces, stackFrames) {
+    this.events = events;
+    this.totalEvents = totalEvents;
+    this.stacktraces = stackTraces;
+    this.stackframes = stackFrames;
+  }
+
+  toElastic() {
+    let facts = [];
+    for (const trace of this.stacktraces) {
+      if (trace.found) {
+        const pairs = ['root'].concat(trace._source.FrameID).map((item, i) => [i, item]);
+        const fact = {
+          id: trace._source.FrameID[trace._source.FrameID.length - 1],
+          value: 1,
+          depth: trace._source.FrameID.length,
+          layers: Object.fromEntries(pairs),
+        };
+        facts.push(fact);
+      }
+    }
+    return { facts };
+  }
+
+  toPixi() {
+    return {};
+  }
+}

--- a/src/plugins/profiling/server/routes/flamegraph.ts
+++ b/src/plugins/profiling/server/routes/flamegraph.ts
@@ -7,11 +7,12 @@
  */
 
 export class FlameGraph {
-  constructor(events, totalEvents, stackTraces, stackFrames) {
+  constructor(events, totalEvents, stackTraces, stackFrames, executables) {
     this.events = events;
     this.totalEvents = totalEvents;
     this.stacktraces = stackTraces;
     this.stackframes = stackFrames;
+    this.executables = executables;
   }
 
   toElastic() {

--- a/src/plugins/profiling/server/routes/load_flameChartElastic.ts
+++ b/src/plugins/profiling/server/routes/load_flameChartElastic.ts
@@ -25,7 +25,7 @@ export function registerFlameChartElasticRoute(router: IRouter<DataRequestHandle
         }),
       },
     },
-   async (ctx, request, response) => {
+    async (ctx, request, response) => {
       const [timeFrom, timeTo] = timeRangeFromRequest(request);
       const src = await import(`../fixtures/flamechart_${timeTo - timeFrom}`);
       delete src.default;

--- a/src/plugins/profiling/server/routes/load_topNHosts.ts
+++ b/src/plugins/profiling/server/routes/load_topNHosts.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import type { DataRequestHandlerContext } from '../../../data/server';
 import type { IRouter } from '../../../../core/server';
-import {getLocalRoutePaths, timeRangeFromRequest} from '../../common';
+import { getLocalRoutePaths, timeRangeFromRequest } from '../../common';
 
 export function registerTraceEventsTopNHostsRoute(router: IRouter<DataRequestHandlerContext>) {
   const paths = getLocalRoutePaths();

--- a/src/plugins/profiling/server/routes/mappings.ts
+++ b/src/plugins/profiling/server/routes/mappings.ts
@@ -123,39 +123,3 @@ export function mapFlamechart(src) {
     facts: newRoot,
   };
 }
-
-export function mapKibanaFlameChart(src) {
-  src.ExeFileName = 'root';
-
-  return {
-    facts: [
-      {
-        id: 'pf-collection-agent: runtime.releaseSudog() in runtime2.go#282',
-        value: 1,
-        depth: 19,
-        layers: {
-          '0': 'root',
-          '1': 'pf-collection-agent: runtime.goexit() in asm_amd64.s#1581',
-          '2': 'pf-collection-agent: github.com/optimyze/prodfiler/pf-storage-backend/storagebackend/storagebackendv1.(*ScyllaExecutor).Start.func1 in scyllaexecutor.go#102',
-          '3': 'pf-collection-agent: github.com/optimyze/prodfiler/pf-storage-backend/storagebackend/storagebackendv1.(*ScyllaExecutor).executeQueryAndReadResults in scyllaexecutor.go#158',
-          '4': 'pf-collection-agent: github.com/gocql/gocql.(*Query).Iter in session.go#1246',
-          '5': 'pf-collection-agent: github.com/gocql/gocql.(*Session).executeQuery in session.go#463',
-          '6': 'pf-collection-agent: github.com/gocql/gocql.(*queryExecutor).executeQuery in query_executor.go#66',
-          '7': 'pf-collection-agent: github.com/gocql/gocql.(*queryExecutor).do in query_executor.go#127',
-          '8': 'pf-collection-agent: github.com/gocql/gocql.(*queryExecutor).attemptQuery in query_executor.go#32',
-          '9': 'pf-collection-agent: github.com/gocql/gocql.(*Query).execute in session.go#1044',
-          '10': 'pf-collection-agent: github.com/gocql/gocql.(*Conn).executeQuery in conn.go#1129',
-          '11': 'pf-collection-agent: github.com/gocql/gocql.(*Conn).exec in conn.go#916',
-          '12': 'pf-collection-agent: github.com/gocql/gocql.(*writeExecuteFrame).writeFrame in frame.go#1618',
-          '13': 'pf-collection-agent: github.com/gocql/gocql.(*framer).writeExecuteFrame in frame.go#1643',
-          '14': 'pf-collection-agent: github.com/gocql/gocql.(*framer).finishWrite in frame.go#788',
-          '15': 'pf-collection-agent: github.com/gocql/gocql.(*Conn).Write in conn.go#319',
-          '16': 'pf-collection-agent: github.com/gocql/gocql.(*writeCoalescer).Write in conn.go#829',
-          '17': 'pf-collection-agent: sync.(*Cond).Wait in cond.go#83',
-          '18': 'pf-collection-agent: sync.runtime_notifyListWait() in sema.go#498',
-          '19': 'pf-collection-agent: runtime.releaseSudog() in runtime2.go#282',
-        },
-      },
-    ],
-  };
-}

--- a/src/plugins/profiling/server/routes/search_flameChart.ts
+++ b/src/plugins/profiling/server/routes/search_flameChart.ts
@@ -30,7 +30,7 @@ export function registerFlameChartSearchRoute(router: IRouter<DataRequestHandler
       try {
         const esClient = context.core.elasticsearch.client.asCurrentUser;
 
-        const resFlamegraphTraces = await esClient.search({
+        const resEvents = await esClient.search({
           index,
           body: {
             query: {
@@ -79,7 +79,7 @@ export function registerFlameChartSearchRoute(router: IRouter<DataRequestHandler
           },
         });
 
-        const resTotalTraces = await esClient.search({
+        const resTotalEvents = await esClient.search({
           index,
           body: {
             query: {
@@ -125,7 +125,7 @@ export function registerFlameChartSearchRoute(router: IRouter<DataRequestHandler
         });
 
         const tracesDocIDs: string[] = [];
-        resFlamegraphTraces.body.aggregations.sample.group_by.buckets.forEach(
+        resEvents.body.aggregations.sample.group_by.buckets.forEach(
           (stackTraceItem: any) => {
             tracesDocIDs.push(stackTraceItem.key);
           }
@@ -154,8 +154,8 @@ export function registerFlameChartSearchRoute(router: IRouter<DataRequestHandler
 
         return response.ok({
           body: {
-            flameChart: resFlamegraphTraces.body,
-            totalTraces: resTotalTraces.body.aggregations,
+            events: resEvents.body,
+            totalEvents: resTotalEvents.body,
             stackTraces: resStackTraces.body.docs,
             stackFrames: resStackFrames.body.docs,
           },

--- a/src/plugins/profiling/server/routes/search_flameChart.ts
+++ b/src/plugins/profiling/server/routes/search_flameChart.ts
@@ -9,6 +9,7 @@ import { schema } from '@kbn/config-schema';
 import type { DataRequestHandlerContext } from '../../../data/server';
 import type { IRouter } from '../../../../core/server';
 import { getRemoteRoutePaths } from '../../common';
+import { FlameGraph } from './flamegraph';
 
 export function registerFlameChartSearchRoute(router: IRouter<DataRequestHandlerContext>) {
   const paths = getRemoteRoutePaths();
@@ -150,13 +151,15 @@ export function registerFlameChartSearchRoute(router: IRouter<DataRequestHandler
           body: { ids: [...stackFrameDocIDs] },
         });
 
+        const flamegraph = new FlameGraph(
+          resEvents.body,
+          resTotalEvents.body,
+          resStackTraces.body.docs,
+          resStackFrames.body.docs
+        );
+
         return response.ok({
-          body: {
-            events: resEvents.body,
-            totalEvents: resTotalEvents.body,
-            stackTraces: resStackTraces.body.docs,
-            stackFrames: resStackFrames.body.docs,
-          },
+          body: flamegraph.toElastic(),
         });
       } catch (e) {
         return response.customError({

--- a/src/plugins/profiling/server/routes/search_topNDeployments.ts
+++ b/src/plugins/profiling/server/routes/search_topNDeployments.ts
@@ -8,7 +8,7 @@
 import type { DataRequestHandlerContext } from '../../../data/server';
 import type { IRouter } from '../../../../core/server';
 import { getRemoteRoutePaths } from '../../common';
-import { queryTopNCommon } from "./search_topN";
+import { queryTopNCommon } from './search_topN';
 
 export function registerTraceEventsTopNDeploymentsSearchRoute(
   router: IRouter<DataRequestHandlerContext>

--- a/src/plugins/profiling/server/routes/search_topNHosts.ts
+++ b/src/plugins/profiling/server/routes/search_topNHosts.ts
@@ -8,7 +8,7 @@
 import type { DataRequestHandlerContext } from '../../../data/server';
 import type { IRouter } from '../../../../core/server';
 import { getRemoteRoutePaths } from '../../common';
-import { queryTopNCommon } from "./search_topN";
+import { queryTopNCommon } from './search_topN';
 
 export function registerTraceEventsTopNHostsSearchRoute(
   router: IRouter<DataRequestHandlerContext>


### PR DESCRIPTION
## Summary

This PR sends the expected response to the Kibana UI so that the Elastic flamegraph will render results.

A few highlights beyond fixing flamegraph rendering:
* All Elasticsearch queries use the same client (`esClient.search` instead of `context.search!.search`)
* Executables are queried again since they will be needed for node labels and other metadata
* Duplicate IDs are removed when querying for stack frames and executables
* `FlameGraph` is a helper class that generates flamegraph-specific responses (this may eventually move to the Kibana UI)

Even though results are now visible again, there are a few caveats that will be addressed in a followup PR:

1. Flamegraph nodes are labeled using the stack trace's docID
2. Stack traces do not factor in their counts (aka samples), thus, each stack trace is weighted the same