### PR TITLE
Fix Elasticsearch query for top N hosts

### DIFF
--- a/src/plugins/profiling/server/routes/search_topNHosts.ts
+++ b/src/plugins/profiling/server/routes/search_topNHosts.ts
@@ -14,5 +14,5 @@ export function registerTraceEventsTopNHostsSearchRoute(
   router: IRouter<DataRequestHandlerContext>
 ) {
   const paths = getRemoteRoutePaths();
-  return queryTopNCommon(router, paths.TopNHosts, 'HostName');
+  return queryTopNCommon(router, paths.TopNHosts, 'HostID');
 }


### PR DESCRIPTION
## Summary

This PR fixes the Elasticsearch query for top N hosts by updating the search term.