### PR TITLE
ES Flamechart: Use down-sampled events indexes

### DIFF
--- a/src/plugins/profiling/public/services.ts
+++ b/src/plugins/profiling/public/services.ts
@@ -21,7 +21,7 @@ function getFetchQuery(seconds: string): HttpFetchQuery {
     index: 'profiling-events',
     projectID: 5,
     timeFrom: unixTime - parseInt(seconds),
-    timeTo: unixTime
+    timeTo: unixTime,
   } as HttpFetchQuery;
 }
 


### PR DESCRIPTION
The PR adds making use of the down-sampled events indexes (`profiling-events-*`) to gather data for the flamegraph (Elastic).

We currently do not have the 'unrolling' of events merged (https://github.com/elastic/prodfiler/pull/2097), so the results are not statistically sound until that PR is merged.
