### PR TITLE
Allow empty Elastic flamegraph

### DIFF
--- a/src/plugins/profiling/INTERNALS.md
+++ b/src/plugins/profiling/INTERNALS.md
@@ -57,7 +57,7 @@ The following example is the expected response:
 
 ```json
 {
-  facts: [
+  leaves: [
     {
       id: 'pf-collection-agent: runtime.releaseSudog() in runtime2.go#282',
       value: 1,
@@ -92,7 +92,7 @@ The following example is the expected response:
 
 Here is a basic description of the response format:
 
-* Each object in the `facts` list represents a node in the flamegraph
+* Each object in the `leaves` list represents a leaf node in the flamegraph
 * `id` represents the name of the flamegraph node
 * `value` represents the number of samples for that node
 * `depth` represents the depth of the node in the flamegraph, starting from zero

--- a/src/plugins/profiling/INTERNALS.md
+++ b/src/plugins/profiling/INTERNALS.md
@@ -62,7 +62,7 @@ The following example is the expected response:
       id: 'pf-collection-agent: runtime.releaseSudog() in runtime2.go#282',
       value: 1,
       depth: 19,
-      layers: {
+      pathFromRoot: {
         '0': 'root',
         '1': 'pf-collection-agent: runtime.goexit() in asm_amd64.s#1581',
         '2': 'pf-collection-agent: github.com/optimyze/prodfiler/pf-storage-backend/storagebackend/storagebackendv1.(*ScyllaExecutor).Start.func1 in scyllaexecutor.go#102',
@@ -96,7 +96,7 @@ Here is a basic description of the response format:
 * `id` represents the name of the flamegraph node
 * `value` represents the number of samples for that node
 * `depth` represents the depth of the node in the flamegraph, starting from zero
-* `layers` represents the full path from the flamegraph root to the given node
+* `pathFromRoot` represents the full path from the flamegraph root to the given node
 
 ### /api/prodfiler/*/flamechart/pixi
 

--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -39,7 +39,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
     series: new Map(),
   });
 
-  const [elasticFlamegraph, setElasticFlamegraph] = useState({});
+  const [elasticFlamegraph, setElasticFlamegraph] = useState({ leaves: [] });
   const [pixiFlamegraph, setPixiFlamegraph] = useState({});
 
   const tabs = [

--- a/src/plugins/profiling/public/components/flamegraph.tsx
+++ b/src/plugins/profiling/public/components/flamegraph.tsx
@@ -36,7 +36,7 @@ export const FlameGraph: React.FC<FlameGraphProps> = ({ id, height }) => {
 
     const result = [...new Array(maxDepth)].map((_, depth) => {
       return {
-        groupByRollup: (d: any) => d.layers[depth],
+        groupByRollup: (d: any) => d.pathFromRoot[depth],
         nodeLabel: (label: PrimitiveValue) => label,
         showAccessor: (n: PrimitiveValue) => !!n,
         shape: {

--- a/src/plugins/profiling/public/components/flamegraph.tsx
+++ b/src/plugins/profiling/public/components/flamegraph.tsx
@@ -27,12 +27,12 @@ export const FlameGraph: React.FC<FlameGraphProps> = ({ id, height }) => {
   });
 
   const layers = useMemo(() => {
-    if (!ctx || !ctx.facts || !ctx.facts.length) {
+    if (!ctx || !ctx.leaves || !ctx.leaves.length) {
       return [];
     }
 
-    const { facts } = ctx;
-    const maxDepth = Math.max(...facts.map((node) => node.depth));
+    const { leaves } = ctx;
+    const maxDepth = Math.max(...leaves.map((node) => node.depth));
 
     const result = [...new Array(maxDepth)].map((_, depth) => {
       return {
@@ -55,7 +55,7 @@ export const FlameGraph: React.FC<FlameGraphProps> = ({ id, height }) => {
         <Settings />
         <Partition
           id={id}
-          data={ctx.facts}
+          data={ctx.leaves}
           layers={layers}
           valueAccessor={(d: any) => d.value as number}
           valueFormatter={() => ''}

--- a/src/plugins/profiling/server/routes/flamegraph.ts
+++ b/src/plugins/profiling/server/routes/flamegraph.ts
@@ -24,7 +24,7 @@ export class FlameGraph {
           id: trace._source.FrameID[trace._source.FrameID.length - 1],
           value: 1,
           depth: trace._source.FrameID.length,
-          layers: Object.fromEntries(pairs),
+          pathFromRoot: Object.fromEntries(pairs),
         };
         leaves.push(fact);
       }

--- a/src/plugins/profiling/server/routes/flamegraph.ts
+++ b/src/plugins/profiling/server/routes/flamegraph.ts
@@ -16,7 +16,7 @@ export class FlameGraph {
   }
 
   toElastic() {
-    let facts = [];
+    let leaves = [];
     for (const trace of this.stacktraces) {
       if (trace.found) {
         const pairs = ['root'].concat(trace._source.FrameID).map((item, i) => [i, item]);
@@ -26,10 +26,10 @@ export class FlameGraph {
           depth: trace._source.FrameID.length,
           layers: Object.fromEntries(pairs),
         };
-        facts.push(fact);
+        leaves.push(fact);
       }
     }
-    return { facts };
+    return { leaves };
   }
 
   toPixi() {

--- a/src/plugins/profiling/server/routes/mappings.ts
+++ b/src/plugins/profiling/server/routes/mappings.ts
@@ -120,6 +120,6 @@ export function mapFlamechart(src) {
   }));
 
   return {
-    facts: newRoot,
+    leaves: newRoot,
   };
 }

--- a/src/plugins/profiling/server/routes/mappings.ts
+++ b/src/plugins/profiling/server/routes/mappings.ts
@@ -88,7 +88,7 @@ function flattenTree(root, depth) {
         id: root.id,
         value: root.value,
         depth: root.depth,
-        layers: {
+        pathFromRoot: {
           [depth]: root.id,
         },
       },
@@ -98,7 +98,7 @@ function flattenTree(root, depth) {
   const children = root.Callees.flatMap((child) => flattenTree(child, depth + 1));
 
   children.forEach((child) => {
-    child.layers[depth] = root.id;
+    child.pathFromRoot[depth] = root.id;
   });
 
   return children;
@@ -116,7 +116,7 @@ export function mapFlamechart(src) {
     id: node.id,
     value: node.value,
     depth: node.depth,
-    layers: node.layers,
+    pathFromRoot: node.pathFromRoot,
   }));
 
   return {


### PR DESCRIPTION
## Summary

This PR fixes the console error seen in https://github.com/optimyze/kibana/pull/7#issuecomment-1032398000 by correctly handing the case where no data is available to the Elastic flamegraph.

I also rolled in a few variable renames to clarify the structure of the data required for the Elastic flamegraph.
