### PR TITLE
Fix empty stacked bar chart for topN hosts

### DIFF
--- a/src/plugins/profiling/common/index.ts
+++ b/src/plugins/profiling/common/index.ts
@@ -53,11 +53,7 @@ export function getTopN(obj) {
       const bucket = obj.topN.histogram.buckets[i];
       for (let j = 0; j < bucket.group_by.buckets.length; j++) {
         const v = bucket.group_by.buckets[j];
-        if (typeof v.key === 'string') {
-          data.push({ x: bucket.key, y: v.Count.value, g: v.key });
-        } else {
-          data.push({ x: bucket.key, y: v.Count.value, g: v.key_as_string });
-        }
+        data.push({ x: bucket.key, y: v.Count.value, g: v.key });
       }
     }
   } else if (obj.TopN !== undefined) {


### PR DESCRIPTION
This PR fixes the empty stacked bar hosts for topN hosts.

The issue was originally reported in https://github.com/optimyze/kibana/pull/14#issuecomment-1036015191.

When grouping items into top N buckets, we relied on the existence of two keys (`key` and `key_as_string`) to provide the topN value to the chart.

If `key` was a string type, then we returned the value of `key_as_string`. Otherwise, we returned the value of `key`.

However, this assumption no longer applies. The HostID value is an unsigned long, but only is available in `key` and `key_as_string` does not exist.