### PR TITLE
Remove superfluous query from flamegraph code

### DIFF
--- a/src/plugins/profiling/server/routes/flamegraph.ts
+++ b/src/plugins/profiling/server/routes/flamegraph.ts
@@ -59,14 +59,12 @@ function getLabel(frame: any, executable: any, type: number) {
 
 export class FlameGraph {
   events: any;
-  totalEvents: any;
   stacktraces: any;
   stackframes: any;
   executables: any;
 
-  constructor(events: any, totalEvents: any, stackTraces: any, stackFrames: any, executables: any) {
+  constructor(events: any, stackTraces: any, stackFrames: any, executables: any) {
     this.events = events;
-    this.totalEvents = totalEvents;
     this.stacktraces = stackTraces;
     this.stackframes = stackFrames;
     this.executables = executables;

--- a/src/plugins/profiling/server/routes/search_flamechart.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.ts
@@ -124,29 +124,6 @@ export function registerFlameChartSearchRoute(router: IRouter<DataRequestHandler
           },
         });
 
-        const resTotalEvents = await esClient.search({
-          index,
-          body: {
-            size: 0,
-            query: filter,
-            aggs: {
-              histogram: {
-                auto_date_histogram: {
-                  field: '@timestamp',
-                  buckets: 100,
-                },
-                aggs: {
-                  Count: {
-                    sum: {
-                      field: 'Count',
-                    },
-                  },
-                },
-              },
-            },
-          },
-        });
-
         const tracesDocIDs: string[] = [];
         resEvents.body.aggregations.sample.group_by.buckets.forEach((stackTraceItem: any) => {
           tracesDocIDs.push(stackTraceItem.key);
@@ -189,7 +166,6 @@ export function registerFlameChartSearchRoute(router: IRouter<DataRequestHandler
 
         const flamegraph = new FlameGraph(
           resEvents.body,
-          resTotalEvents.body,
           resStackTraces.body.docs,
           resStackFrames.body.docs,
           resExecutables.body.docs


### PR DESCRIPTION
For displaying our flamegraphs we do not need aggregated Count values by timestamp bucket.

What we will need is the sum of all Count values to display the 'samples' and % values correctly in the blocks. That will be added in #16.