### PR TITLE
improve query latency, add topN filter

### DIFF
--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -78,7 +78,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
           <EuiSpacer />
           <FlameGraphContext.Provider value={pixiFlamegraph}>
             <FlameGraphNavigation getter={fetchPixiFlamechart} setter={setPixiFlamegraph} />
-            <PixiFlamechart projectID={5} />
+            <PixiFlamechart projectID={'5'} />
           </FlameGraphContext.Provider>
         </>
       ),

--- a/src/plugins/profiling/public/services.ts
+++ b/src/plugins/profiling/public/services.ts
@@ -20,8 +20,10 @@ function getFetchQuery(seconds: string): HttpFetchQuery {
   return {
     index: 'profiling-events',
     projectID: 5,
-    timeFrom: unixTime - parseInt(seconds),
+    timeFrom: unixTime - parseInt(seconds, 10),
     timeTo: unixTime,
+    // TODO remove hard-coded value for topN items length and expose it through the UI
+    n: 100,
   } as HttpFetchQuery;
 }
 
@@ -33,11 +35,7 @@ export function getServices(core: CoreStart): Services {
     fetchTopN: async (type: string, seconds: string) => {
       try {
         const query = getFetchQuery(seconds);
-        const response = await core.http.get(
-          `${paths.TopN}/${type}`,
-          { query }
-        );
-        return response;
+        return await core.http.get(`${paths.TopN}/${type}`, { query });
       } catch (e) {
         return e;
       }
@@ -46,11 +44,7 @@ export function getServices(core: CoreStart): Services {
     fetchElasticFlamechart: async (seconds: string) => {
       try {
         const query = getFetchQuery(seconds);
-        const response = await core.http.get(
-          paths.FlamechartElastic,
-          { query }
-        );
-        return response;
+        return await core.http.get(paths.FlamechartElastic, { query });
       } catch (e) {
         return e;
       }
@@ -59,11 +53,7 @@ export function getServices(core: CoreStart): Services {
     fetchPixiFlamechart: async (seconds: string) => {
       try {
         const query = getFetchQuery(seconds);
-        const response = await core.http.get(
-          paths.FlamechartPixi,
-          { query }
-        );
-        return response;
+        return await core.http.get(paths.FlamechartPixi, { query });
       } catch (e) {
         return e;
       }

--- a/src/plugins/profiling/server/routes/mappings.ts
+++ b/src/plugins/profiling/server/routes/mappings.ts
@@ -59,12 +59,13 @@ export function newProjectTimeQuery(
 }
 
 export function autoHistogramSumCountOnGroupByField(
-  searchField: string
+  searchField: string,
+  topNItems: number
 ): AggregationsAggregationContainer {
   return {
     auto_date_histogram: {
       field: '@timestamp',
-      buckets: 100,
+      buckets: 50,
     },
     aggs: {
       group_by: {
@@ -74,7 +75,7 @@ export function autoHistogramSumCountOnGroupByField(
           // ordering of Elasticsearch: by default this will be the descending count
           // of matched documents. This is not equal to the ordering by sum of Count field,
           // but it's a good-enough approximation given the distribution of Count.
-          size: 100,
+          size: topNItems,
         },
         aggs: {
           Count: {

--- a/src/plugins/profiling/server/routes/mappings.ts
+++ b/src/plugins/profiling/server/routes/mappings.ts
@@ -10,13 +10,10 @@ import { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api
 
 interface ProjectTimeQuery {
   bool: {
-    must: Array<
+    filter: Array<
       | {
           term: {
-            ProjectID: {
-              value: string;
-              boost: number;
-            };
+            ProjectID: string;
           };
         }
       | {
@@ -40,13 +37,10 @@ export function newProjectTimeQuery(
 ): ProjectTimeQuery {
   return {
     bool: {
-      must: [
+      filter: [
         {
           term: {
-            ProjectID: {
-              value: projectID,
-              boost: 1.0,
-            },
+            ProjectID: projectID,
           },
         },
         {
@@ -76,9 +70,10 @@ export function autoHistogramSumCountOnGroupByField(
       group_by: {
         terms: {
           field: searchField,
-          order: {
-            Count: 'desc',
-          },
+          // We remove the ordering since we will rely directly on the natural
+          // ordering of Elasticsearch: by default this will be the descending count
+          // of matched documents. This is not equal to the ordering by sum of Count field,
+          // but it's a good-enough approximation given the distribution of Count.
           size: 100,
         },
         aggs: {

--- a/src/plugins/profiling/server/routes/search_topn.test.ts
+++ b/src/plugins/profiling/server/routes/search_topn.test.ts
@@ -9,7 +9,13 @@
 import { topNElasticSearchQuery } from './search_topn';
 import { DataRequestHandlerContext } from '../../../data/server';
 import { kibanaResponseFactory } from '../../../../core/server';
-import { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/types';
+import {
+  AggregationsAggregationContainer,
+  AggregationsHistogramAggregate,
+  AggregationsHistogramBucket,
+  AggregationsMultiBucketAggregateBase,
+  AggregationsStringTermsBucket,
+} from '@elastic/elasticsearch/lib/api/types';
 
 const anyQuery = 'any::query';
 const index = 'test';
@@ -36,23 +42,23 @@ function mockTopNData() {
                   histogram: {
                     buckets: [
                       {
-                        key_as_string: '1644506880',
-                        key: 1644506880000,
-                        doc_count: 700,
+                        key_as_string: '123',
+                        key: 123000,
+                        doc_count: 10,
                         group_by: {
                           buckets: [
                             {
-                              key: 'vyHke_Kdp2c05tXV7a_Rkg==',
+                              key: '::any::key::',
                               doc_count: 10,
                               Count: {
                                 value: 100.0,
                               },
-                            },
+                            } as AggregationsStringTermsBucket,
                           ],
-                        },
-                      },
+                        } as AggregationsMultiBucketAggregateBase<AggregationsStringTermsBucket>,
+                      } as AggregationsHistogramBucket,
                     ],
-                  },
+                  } as AggregationsHistogramAggregate,
                 },
               },
             }),

--- a/src/plugins/profiling/server/routes/search_topn.ts
+++ b/src/plugins/profiling/server/routes/search_topn.ts
@@ -22,6 +22,7 @@ export async function topNElasticSearchQuery(
   projectID: string,
   timeFrom: string,
   timeTo: string,
+  topNItems: number,
   searchField: string,
   response: KibanaResponseFactory
 ) {
@@ -31,7 +32,7 @@ export async function topNElasticSearchQuery(
     body: {
       query: newProjectTimeQuery(projectID, timeFrom, timeTo),
       aggs: {
-        histogram: autoHistogramSumCountOnGroupByField(searchField),
+        histogram: autoHistogramSumCountOnGroupByField(searchField, topNItems),
       },
     },
   });
@@ -76,23 +77,25 @@ export function queryTopNCommon(
       path: pathName,
       validate: {
         query: schema.object({
-          index: schema.maybe(schema.string()),
-          projectID: schema.maybe(schema.string()),
-          timeFrom: schema.maybe(schema.string()),
-          timeTo: schema.maybe(schema.string()),
+          index: schema.string(),
+          projectID: schema.string(),
+          timeFrom: schema.string(),
+          timeTo: schema.string(),
+          n: schema.number(),
         }),
       },
     },
     async (context, request, response) => {
-      const { index, projectID, timeFrom, timeTo } = request.query;
+      const { index, projectID, timeFrom, timeTo, n } = request.query;
 
       try {
         return await topNElasticSearchQuery(
           context,
-          index!,
-          projectID!,
-          timeFrom!,
-          timeTo!,
+          index,
+          projectID,
+          timeFrom,
+          timeTo,
+          n,
           searchField,
           response
         );


### PR DESCRIPTION
## Summary

These could've been 2 PRs, but while I was at it I thought I could bundle it.
The commits are isolated to ease review:
* improve the query latency with a 30% speed up of query latency on the unsampled `profiling-event` index, by removing the `order` clause in aggregation and relying on natural ordering by Elasticsearch done on document count
* topN returned elements reduction using an additional query string parameter (plus unrelated linting required by the pre-commit hook)

Note on the second commit: I still didn't figure out a way to include the new query string parameter via a react component.
Will do so in future PRs but the API can already be tested calling

```
/api/prodfiler/v2/topn/threads?index=profiling-events&projectID=5&timeFrom=1644943196&timeTo=1644944996&n=5
```

with the addtional `n=X` indicating the number of items that will be returned for every time bucket.
This mimics the TopN function logic we used to have in Prodfiler and helps speeding up the retrieval and parsing of response.
