### PR TITLE
Use bar chart title to label data in tooltip

### DIFF
--- a/src/plugins/profiling/public/components/chart-grid.tsx
+++ b/src/plugins/profiling/public/components/chart-grid.tsx
@@ -37,7 +37,7 @@ export const ChartGrid: React.FC<ChartGridProps> = ({ maximum }) => {
       const uniqueID = `bar-chart-${i}`;
 
       const barchart = (
-        <BarChart id={uniqueID} name={uniqueID} height={200} data={subdata} x="x" y="y" />
+        <BarChart id={uniqueID} name={keys[i]} height={200} data={subdata} x="x" y="y" />
       );
 
       const title = (


### PR DESCRIPTION
This PR changes the hover tooltip to use the respective bar chart title.

Previously the internal ID for an individual bar chart was used to identify the series data in the tooltip. This was confusing so now the series name is used to label the data points in the tooltip.

If you hover over a bar chart now, you will no longer see something like `bar-chart-xyz` as the label for the data points.