### PR TITLE
Fix the data aggregation for the flamegraph

### DIFF
--- a/src/plugins/profiling/common/index.ts
+++ b/src/plugins/profiling/common/index.ts
@@ -88,3 +88,18 @@ export function timeRangeFromRequest(request: any): [number, number] {
   const timeTo = parseInt(request.query.timeTo!, 10);
   return [timeFrom, timeTo];
 }
+
+export const now = (label?: string) => {
+  if (label) {
+    console.log('Started', label);
+  }
+  return new Date().getTime();
+};
+
+export const elapsed = (start: number, label?: string) => {
+  const duration = new Date().getTime() - start;
+  if (label) {
+    console.log(label, `${duration / 1000}s`);
+  }
+  return duration;
+};

--- a/src/plugins/profiling/server/routes/search_flamechart.test.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.test.ts
@@ -49,9 +49,9 @@ describe('Using down-sampled indexes', () => {
     ];
 
     for (const t of tests) {
-      expect(getSampledTraceEventsIndex(targetSampleSize, t.sampleCountFromPow6, initialExp)).toEqual(
-        t.expected
-      );
+      expect(
+        getSampledTraceEventsIndex(targetSampleSize, t.sampleCountFromPow6, initialExp)
+      ).toEqual(t.expected);
     }
   });
 });

--- a/src/plugins/profiling/server/routes/types.ts
+++ b/src/plugins/profiling/server/routes/types.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export type StackTraceID = string;
+export type StackFrameID = string;
+export type FileID = string;
+
+export interface StackTraceEvent {
+  StackTraceID: StackTraceID;
+  Count: number;
+}
+
+export interface StackTrace {
+  FileID: string[];
+  FrameID: string[];
+  Type: string[];
+}
+
+export interface StackFrame {
+  FileName: string;
+  FunctionName: string;
+  FunctionOffset: number;
+  LineNumber: number;
+  SourceType: number;
+}
+
+export interface Executable {
+  FileName: string;
+}


### PR DESCRIPTION
Hm, just when pushing it, a voice inside told me this is wrong as well. Since in the flamegraph we aggregate traces by the first frame. So I have to fetch the first frameID for each unique StackTraceID and aggregate those.

In this PR (first version) we aggregate by StackTraceID (wrong !).