### PR TITLE
Use logger instead of conosle.log

### DIFF
--- a/src/plugins/profiling/common/index.ts
+++ b/src/plugins/profiling/common/index.ts
@@ -47,7 +47,7 @@ function toMilliseconds(seconds: string): number {
 export function getTopN(obj) {
   const data = [];
 
-  if (obj.topN?.histogram?.buckets !== undefined) {
+  if (obj.topN?.histogram?.buckets!) {
     // needed for data served from Elasticsearch
     for (let i = 0; i < obj.topN.histogram.buckets.length; i++) {
       const bucket = obj.topN.histogram.buckets[i];
@@ -56,13 +56,15 @@ export function getTopN(obj) {
         data.push({ x: bucket.key, y: v.Count.value, g: v.key });
       }
     }
-  } else if (obj.TopN !== undefined) {
+  } else if (obj.TopN!) {
     // needed for data served from fixtures
     for (const x in obj.TopN) {
-      const values = obj.TopN[x];
-      for (let i = 0; i < values.length; i++) {
-        const v = values[i];
-        data.push({ x: toMilliseconds(x), y: v.Count, g: v.Value });
+      if (obj.TopN.hasOwnProperty(x)) {
+        const values = obj.TopN[x];
+        for (let i = 0; i < values.length; i++) {
+          const v = values[i];
+          data.push({ x: toMilliseconds(x), y: v.Count, g: v.Value });
+        }
       }
     }
   }
@@ -88,18 +90,3 @@ export function timeRangeFromRequest(request: any): [number, number] {
   const timeTo = parseInt(request.query.timeTo!, 10);
   return [timeFrom, timeTo];
 }
-
-export const now = (label?: string) => {
-  if (label) {
-    console.log('Started', label);
-  }
-  return new Date().getTime();
-};
-
-export const elapsed = (start: number, label?: string) => {
-  const duration = new Date().getTime() - start;
-  if (label) {
-    console.log(label, `${duration / 1000}s`);
-  }
-  return duration;
-};

--- a/src/plugins/profiling/server/plugin.ts
+++ b/src/plugins/profiling/server/plugin.ts
@@ -5,13 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import {
-  PluginInitializerContext,
-  CoreSetup,
-  CoreStart,
-  Plugin,
-  Logger,
-} from '../../../core/server';
+import { PluginInitializerContext, CoreSetup, CoreStart, Plugin, Logger } from 'kibana/server';
 
 import type { DataRequestHandlerContext } from '../../data/server';
 
@@ -46,7 +40,7 @@ export class ProfilingPlugin
     core.getStartServices().then(([_, depsStart]) => {
       const myStrategy = mySearchStrategyProvider(depsStart.data);
       deps.data.search.registerSearchStrategy('myStrategy', myStrategy);
-      registerRoutes(router);
+      registerRoutes(router, this.logger);
     });
 
     return {};

--- a/src/plugins/profiling/server/routes/index.ts
+++ b/src/plugins/profiling/server/routes/index.ts
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import type { IRouter } from 'kibana/server';
+import type { IRouter, Logger } from 'kibana/server';
 import { DataRequestHandlerContext } from '../../../data/server';
 import { registerFlameChartElasticRoute, registerFlameChartPixiRoute } from './load_flamechart';
 import {
@@ -25,7 +25,7 @@ import {
   registerTraceEventsTopNThreadsSearchRoute,
 } from './search_topn';
 
-export function registerRoutes(router: IRouter<DataRequestHandlerContext>) {
+export function registerRoutes(router: IRouter<DataRequestHandlerContext>, logger?: Logger) {
   registerFlameChartElasticRoute(router);
   registerFlameChartPixiRoute(router);
   registerTraceEventsTopNContainersRoute(router);
@@ -34,7 +34,7 @@ export function registerRoutes(router: IRouter<DataRequestHandlerContext>) {
   registerTraceEventsTopNStackTracesRoute(router);
   registerTraceEventsTopNThreadsRoute(router);
 
-  registerFlameChartSearchRoute(router);
+  registerFlameChartSearchRoute(router, logger!);
   registerTraceEventsTopNContainersSearchRoute(router);
   registerTraceEventsTopNDeploymentsSearchRoute(router);
   registerTraceEventsTopNHostsSearchRoute(router);


### PR DESCRIPTION
## Summary

Remove the use of console.log (lint error) to use the plugin's built-in logging mechanism.

This enables logs in the server like the following:

```
[2022-02-24T18:05:04.603+01:00][INFO ][status] Kibana is now available (was degraded)
[2022-02-24T18:06:19.456+01:00][INFO ][plugins.profiling] query to find DownsampledIndex took 0ms
[2022-02-24T18:06:19.459+01:00][INFO ][plugins.profiling] sampleCountFromPow6 14
[2022-02-24T18:06:19.459+01:00][INFO ][plugins.profiling] EventsIndex profiling-events-5pow1
[2022-02-24T18:06:19.460+01:00][INFO ][plugins.profiling] query to find DownsampledIndex took 1ms
[2022-02-24T18:06:19.586+01:00][INFO ][plugins.profiling] query time registered by ES on events 58
[2022-02-24T18:06:19.586+01:00][INFO ][plugins.profiling] events document count 44799
[2022-02-24T18:06:19.587+01:00][INFO ][plugins.profiling] total events count 45787
[2022-02-24T18:06:19.587+01:00][INFO ][plugins.profiling] unique events 33570
[2022-02-24T18:06:19.591+01:00][INFO ][plugins.profiling] mget query for stacktraces took 4ms
[2022-02-24T18:06:22.915+01:00][INFO ][plugins.profiling] unique stacktraces 33570
[2022-02-24T18:06:23.151+01:00][INFO ][plugins.profiling] unique frames62672
[2022-02-24T18:06:23.160+01:00][INFO ][plugins.profiling] mget query for stackframes took 9ms
[2022-02-24T18:06:24.704+01:00][INFO ][plugins.profiling] unique executable IDs 18704
[2022-02-24T18:06:24.711+01:00][INFO ][plugins.profiling] mget query for executables took 6ms
[2022-02-24T18:06:24.977+01:00][INFO ][plugins.profiling] building Flamegraph data took 29ms
```

The only caveat is that we used `INFO` because `DEBUG` it's not the default level even in development mode.