### PR TITLE
Add Pixi flamechart route to query Elasticsearch

### DIFF
--- a/src/plugins/profiling/server/routes/index.ts
+++ b/src/plugins/profiling/server/routes/index.ts
@@ -16,7 +16,11 @@ import {
   registerTraceEventsTopNThreadsRoute,
 } from './load_topn';
 
-import { registerFlameChartElasticSearchRoute } from './search_flamechart';
+import {
+  registerFlameChartElasticSearchRoute,
+  registerFlameChartPixiSearchRoute,
+} from './search_flamechart';
+
 import {
   registerTraceEventsTopNContainersSearchRoute,
   registerTraceEventsTopNDeploymentsSearchRoute,
@@ -35,6 +39,7 @@ export function registerRoutes(router: IRouter<DataRequestHandlerContext>, logge
   registerTraceEventsTopNThreadsRoute(router);
 
   registerFlameChartElasticSearchRoute(router, logger!);
+  registerFlameChartPixiSearchRoute(router, logger!);
   registerTraceEventsTopNContainersSearchRoute(router);
   registerTraceEventsTopNDeploymentsSearchRoute(router);
   registerTraceEventsTopNHostsSearchRoute(router);

--- a/src/plugins/profiling/server/routes/index.ts
+++ b/src/plugins/profiling/server/routes/index.ts
@@ -16,7 +16,7 @@ import {
   registerTraceEventsTopNThreadsRoute,
 } from './load_topn';
 
-import { registerFlameChartSearchRoute } from './search_flamechart';
+import { registerFlameChartElasticSearchRoute } from './search_flamechart';
 import {
   registerTraceEventsTopNContainersSearchRoute,
   registerTraceEventsTopNDeploymentsSearchRoute,
@@ -34,7 +34,7 @@ export function registerRoutes(router: IRouter<DataRequestHandlerContext>, logge
   registerTraceEventsTopNStackTracesRoute(router);
   registerTraceEventsTopNThreadsRoute(router);
 
-  registerFlameChartSearchRoute(router, logger!);
+  registerFlameChartElasticSearchRoute(router, logger!);
   registerTraceEventsTopNContainersSearchRoute(router);
   registerTraceEventsTopNDeploymentsSearchRoute(router);
   registerTraceEventsTopNHostsSearchRoute(router);

--- a/src/plugins/profiling/server/routes/search_flamechart.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.ts
@@ -6,11 +6,11 @@
  * Side Public License, v 1.
  */
 import { schema } from '@kbn/config-schema';
-import type { IRouter, Logger } from 'kibana/server';
+import type { ElasticsearchClient, IRouter, Logger } from 'kibana/server';
 import type { DataRequestHandlerContext } from '../../../data/server';
 import { getRemoteRoutePaths } from '../../common';
 import { FlameGraph } from './flamegraph';
-import { newProjectTimeQuery } from './mappings';
+import { newProjectTimeQuery, ProjectTimeQuery } from './mappings';
 import { Executable, FileID, StackFrame, StackFrameID, StackTrace, StackTraceID } from './types';
 
 export interface DownsampledEventsIndex {
@@ -65,6 +65,213 @@ export function getSampledTraceEventsIndex(
   return { name: downsampledIndex + initialExp, sampleRate: 1 / samplingFactor ** initialExp };
 }
 
+async function queryFlameGraph(
+  logger: Logger,
+  client: ElasticsearchClient,
+  filter: ProjectTimeQuery,
+  sampleSize: number
+): Promise<FlameGraph> {
+  // Start with counting the results in the index down-sampled by 5^6.
+  // That is in the middle of our down-sampled indexes.
+  const initialExp = 6;
+
+  const eventsIndex = await logExecutionLatency(
+    logger,
+    'query to find DownsampledIndex',
+    async () => {
+      const resp = await client.search({
+        index: downsampledIndex + initialExp,
+        body: {
+          query: filter,
+          size: 0,
+          track_total_hits: true,
+        },
+      });
+      const sampleCountFromInitialExp = resp.body.hits.total?.value as number;
+
+      logger.info('sampleCountFromPow6 ' + sampleCountFromInitialExp);
+
+      return getSampledTraceEventsIndex(sampleSize, sampleCountFromInitialExp, initialExp);
+    }
+  );
+  logger.info('EventsIndex ' + eventsIndex.name);
+
+  // Using filter_path is less readable and scrollSearch seems to be buggy - it
+  // applies filter_path only to the first array of results, but not on the following arrays.
+  // The downside of `_source` is: it takes 2.5x more time on the ES side (see "took" field).
+  // The `composite` keyword skips sorting the buckets as and return results 'as is'.
+  // A max bucket size of 100000 needs a cluster level setting "search.max_buckets: 100000".
+  const resEvents = await logExecutionLatency(
+    logger,
+    'query to find DownsampledIndex',
+    async () => {
+      return await client.search({
+        index: eventsIndex.name,
+        size: 0,
+        query: filter,
+        aggs: {
+          group_by: {
+            composite: {
+              size: 100000, // This is the upper limit of entries per event index.
+              sources: [
+                {
+                  traceid: {
+                    terms: {
+                      field: 'StackTraceID',
+                    },
+                  },
+                },
+              ],
+            },
+            aggs: {
+              sum_count: {
+                sum: {
+                  field: 'Count',
+                },
+              },
+            },
+          },
+          total_count: {
+            sum: {
+              field: 'Count',
+            },
+          },
+        },
+      });
+    }
+  );
+
+  const totalCount: number = resEvents.body.aggregations.total_count.value;
+  const stackTraceEvents = new Map<StackTraceID, number>();
+
+  let docCount = 0;
+  let bucketCount = 0;
+  resEvents.body.aggregations.group_by.buckets.forEach((item: any) => {
+    const traceid: StackTraceID = item.key.traceid;
+    stackTraceEvents.set(traceid, item.sum_count.value);
+    docCount += item.doc_count;
+    bucketCount++;
+  });
+  console.log('took', resEvents.body.took);
+  console.log('docs', docCount);
+  console.log('total events', totalCount);
+  console.log('unique events', bucketCount);
+
+  const resStackTraces = await logExecutionLatency(
+    logger,
+    'mget query for stacktraces',
+    async () => {
+      return await client.mget({
+        index: 'profiling-stacktraces',
+        ids: [...stackTraceEvents.keys()],
+        _source_includes: ['FrameID', 'FileID', 'Type'],
+      });
+    }
+  );
+
+  // Sometimes we don't find the trace.
+  // This is due to ES delays writing (data is not immediately seen after write).
+  // Also, ES doesn't know about transactions.
+
+  // Create a lookup map StackTraceID -> StackTrace.
+  let stackTraces = new Map<StackTraceID, StackTrace>();
+  for (const trace of resStackTraces.body.docs) {
+    if (trace.found) {
+      stackTraces.set(trace._id, {
+        FileID: trace._source.FileID,
+        FrameID: trace._source.FrameID,
+        Type: trace._source.Type,
+      });
+    }
+  }
+  console.log('unique stacktraces', stackTraces.size);
+
+  // Create the set of unique FrameIDs.
+  const stackFrameDocIDs = new Set<string>();
+  for (const trace of stackTraces.values()) {
+    for (const frameID of trace.FrameID) {
+      stackFrameDocIDs.add(frameID);
+    }
+  }
+  console.log('unique frames', stackFrameDocIDs.size);
+
+  const resStackFrames = await logExecutionLatency(
+    logger,
+    'mget query for stackframes',
+    async () => {
+      return await client.mget({
+        index: 'profiling-stackframes',
+        ids: [...stackFrameDocIDs],
+      });
+    }
+  );
+
+  // Create a lookup map StackFrameID -> StackFrame.
+  const stackFrames = new Map<StackFrameID, StackFrame>();
+  for (const frame of resStackFrames.body.docs) {
+    if (frame.found) {
+      stackFrames.set(frame._id, frame._source);
+    } else {
+      stackFrames.set(frame._id, {
+        FileName: '',
+        FunctionName: '',
+        FunctionOffset: 0,
+        LineNumber: 0,
+        SourceType: 0,
+      });
+    }
+  }
+
+  // Create the set of unique executable FileIDs.
+  const executableDocIDs = new Set<string>();
+  for (const trace of stackTraces.values()) {
+    for (const fileID of trace.FileID) {
+      executableDocIDs.add(fileID);
+    }
+  }
+  console.log('unique executable IDs', executableDocIDs.size);
+
+  const resExecutables = await logExecutionLatency(
+    logger,
+    'mget query for executables',
+    async () => {
+      return await client.mget<any>({
+        index: 'profiling-executables',
+        ids: [...executableDocIDs],
+        _source_includes: ['FileName'],
+      });
+    }
+  );
+
+  // Create a lookup map StackFrameID -> StackFrame.
+  const executables = new Map<FileID, Executable>();
+  for (const exe of resExecutables.body.docs) {
+    if (exe.found) {
+      executables.set(exe._id, exe._source);
+    } else {
+      executables.set(exe._id, {
+        FileName: '',
+      });
+    }
+  }
+
+  return logExecutionLatency<any>(logger, 'building Flamegraph data', () => {
+    return new Promise((resolve, _) => {
+      return resolve(
+        new FlameGraph(
+          eventsIndex.sampleRate,
+          totalCount,
+          stackTraceEvents,
+          stackTraces,
+          stackFrames,
+          executables,
+          logger
+        )
+      );
+    });
+  });
+}
+
 export function registerFlameChartSearchRoute(
   router: IRouter<DataRequestHandlerContext>,
   logger: Logger
@@ -91,216 +298,10 @@ export function registerFlameChartSearchRoute(
         const esClient = context.core.elasticsearch.client.asCurrentUser;
         const filter = newProjectTimeQuery(projectID!, timeFrom!, timeTo!);
 
-        // Start with counting the results in the index down-sampled by 5^6.
-        // That is in the middle of our down-sampled indexes.
-        const initialExp = 6;
-
-        const eventsIndex = await logExecutionLatency(
-          logger,
-          'query to find DownsampledIndex',
-          async () => {
-            const resp = await esClient.search({
-              index: downsampledIndex + initialExp,
-              body: {
-                query: filter,
-                size: 0,
-                track_total_hits: true,
-              },
-            });
-            const sampleCountFromInitialExp = resp.body.hits.total?.value as number;
-
-            logger.info('sampleCountFromPow6 ' + sampleCountFromInitialExp);
-
-            return getSampledTraceEventsIndex(
-              targetSampleSize,
-              sampleCountFromInitialExp,
-              initialExp
-            );
-          }
-        );
-        logger.info('EventsIndex ' + eventsIndex.name);
-
-        // Using filter_path is less readable and scrollSearch seems to be buggy - it
-        // applies filter_path only to the first array of results, but not on the following arrays.
-        // The downside of `_source` is: it takes 2.5x more time on the ES side (see "took" field).
-        // The `composite` keyword skips sorting the buckets as and return results 'as is'.
-        // A max bucket size of 100000 needs a cluster level setting "search.max_buckets: 100000".
-        const resEvents = await logExecutionLatency(
-          logger,
-          'query to find DownsampledIndex',
-          async () => {
-            return await esClient.search({
-              index: eventsIndex.name,
-              size: 0,
-              query: filter,
-              aggs: {
-                group_by: {
-                  composite: {
-                    size: 100000, // This is the upper limit of entries per event index.
-                    sources: [
-                      {
-                        traceid: {
-                          terms: {
-                            field: 'StackTraceID',
-                          },
-                        },
-                      },
-                    ],
-                  },
-                  aggs: {
-                    sum_count: {
-                      sum: {
-                        field: 'Count',
-                      },
-                    },
-                  },
-                },
-                total_count: {
-                  sum: {
-                    field: 'Count',
-                  },
-                },
-              },
-            });
-          }
-        );
-
-        const totalCount: number = resEvents.body.aggregations?.total_count.value;
-        const stackTraceEvents = new Map<StackTraceID, number>();
-
-        let docCount = 0;
-        let bucketCount = 0;
-        resEvents.body.aggregations?.group_by.buckets.forEach((item: any) => {
-          const traceid: StackTraceID = item.key.traceid;
-          stackTraceEvents.set(traceid, item.sum_count.value);
-          docCount += item.doc_count;
-          bucketCount++;
-        });
-        logger.info('query time registered by ES on events ' + resEvents.body.took);
-        logger.info('events document count ' + docCount);
-        logger.info('total events count ' + totalCount);
-        logger.info('unique events ' + bucketCount);
-
-        const resStackTraces = await logExecutionLatency(
-          logger,
-          'mget query for stacktraces',
-          async () => {
-            return await esClient.mget({
-              index: 'profiling-stacktraces',
-              ids: [...stackTraceEvents.keys()],
-              _source_includes: ['FrameID', 'FileID', 'Type'],
-            });
-          }
-        );
-
-        // Sometimes we don't find the trace.
-        // This is due to ES delays writing (data is not immediately seen after write).
-        // Also, ES doesn't know about transactions.
-
-        // Create a lookup map StackTraceID -> StackTrace.
-        const stackTraces = new Map<StackTraceID, StackTrace>();
-        for (const trace of resStackTraces.body.docs) {
-          if (trace.found) {
-            stackTraces.set(trace._id, {
-              FileID: trace._source.FileID,
-              FrameID: trace._source.FrameID,
-              Type: trace._source.Type,
-            });
-          }
-        }
-        logger.info('unique stacktraces ' + stackTraces.size);
-
-        // Create the set of unique FrameIDs.
-        const stackFrameDocIDs = new Set<string>();
-        for (const trace of stackTraces.values()) {
-          for (const frameID of trace.FrameID) {
-            stackFrameDocIDs.add(frameID);
-          }
-        }
-        logger.info('unique frames' + stackFrameDocIDs.size);
-
-        const resStackFrames = await logExecutionLatency(
-          logger,
-          'mget query for stackframes',
-          async () => {
-            return await esClient.mget({
-              index: 'profiling-stackframes',
-              ids: [...stackFrameDocIDs],
-            });
-          }
-        );
-
-        // Create a lookup map StackFrameID -> StackFrame.
-        const stackFrames = new Map<StackFrameID, StackFrame>();
-        for (const frame of resStackFrames.body.docs) {
-          if (frame.found) {
-            stackFrames.set(frame._id, frame._source);
-          } else {
-            stackFrames.set(frame._id, {
-              FileName: '',
-              FunctionName: '',
-              FunctionOffset: 0,
-              LineNumber: 0,
-              SourceType: 0,
-            });
-          }
-        }
-
-        // Create the set of unique executable FileIDs.
-        const executableDocIDs = new Set<string>();
-        for (const trace of stackTraces.values()) {
-          for (const fileID of trace.FileID) {
-            executableDocIDs.add(fileID);
-          }
-        }
-        logger.info('unique executable IDs ' + executableDocIDs.size);
-
-        const resExecutables = await logExecutionLatency(
-          logger,
-          'mget query for executables',
-          async () => {
-            return await esClient.mget<any>({
-              index: 'profiling-executables',
-              ids: [...executableDocIDs],
-              _source_includes: ['FileName'],
-            });
-          }
-        );
-
-        // Create a lookup map StackFrameID -> StackFrame.
-        const executables = new Map<FileID, Executable>();
-        for (const exe of resExecutables.body.docs) {
-          if (exe.found) {
-            executables.set(exe._id, exe._source);
-          } else {
-            executables.set(exe._id, {
-              FileName: '',
-            });
-          }
-        }
-
-        const responseBody = await logExecutionLatency<any>(
-          logger,
-          'building Flamegraph data',
-          () => {
-            return new Promise((resolve, _) => {
-              return resolve(
-                new FlameGraph(
-                  eventsIndex.sampleRate,
-                  totalCount,
-                  stackTraceEvents,
-                  stackTraces,
-                  stackFrames,
-                  executables,
-                  logger
-                ).toElastic()
-              );
-            });
-          }
-        );
+        const flamegraph = await queryFlameGraph(logger, esClient, filter, targetSampleSize);
 
         return response.ok({
-          body: responseBody,
+          body: flamegraph.toElastic(),
         });
       } catch (e) {
         logger.error('Caught exception when fetching Flamegraph data: ' + e.message);

--- a/src/plugins/profiling/server/routes/search_flamechart.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.ts
@@ -272,7 +272,7 @@ async function queryFlameGraph(
   });
 }
 
-export function registerFlameChartSearchRoute(
+export function registerFlameChartElasticSearchRoute(
   router: IRouter<DataRequestHandlerContext>,
   logger: Logger
 ) {


### PR DESCRIPTION
This PR registers a route for the Pixi flamechart API endpoint that queries the Elasticsearch cluster.

Since the Elastic and Pixi flamegraph responses use the same data, I created this PR to also refactor out the common query to prevent future rebase difficulties while work continues on defining the non-empty Pixi flamegraph response.