### PR TITLE
Increase timeout in the dev console from 30s to 300s (5min)

### DIFF
--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -60,7 +60,7 @@
 
 # Time in milliseconds to wait for responses from the back end or Elasticsearch. This value
 # must be a positive integer.
-#elasticsearch.requestTimeout: 30000
+elasticsearch.requestTimeout: 300000
 
 # List of Kibana client-side headers to send to Elasticsearch. To send *no* client-side
 # headers, set this value to [] (an empty list).
@@ -71,7 +71,7 @@
 #elasticsearch.customHeaders: {}
 
 # Time in milliseconds for Elasticsearch to wait for responses from shards. Set to 0 to disable.
-#elasticsearch.shardTimeout: 30000
+elasticsearch.shardTimeout: 300000
 
 # =================== System: Elasticsearch (Optional) ===================
 # These files are used to verify the identity of Kibana to Elasticsearch and are required when


### PR DESCRIPTION
In our MVP cluster we often run into a 30s timeout due to the amount of data we ingested.
For testing, we sometimes need a higher timeout.

We can not increase the timeout via the dev console itself.
So we have to do it via `kubectl edit kibana`.

This PR documents the changes in case we want to amend/revert them.