### PR TITLE
Add FlameGraph (Elastic2) tab for comparison of index mappings

### DIFF
--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -33,13 +33,19 @@ import { Services } from './services';
 
 type Props = Services;
 
-function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) {
+function App({
+  fetchTopN,
+  fetchElasticFlamechart,
+  fetchElasticFlamechart2,
+  fetchPixiFlamechart,
+}: Props) {
   const [topn, setTopN] = useState({
     samples: [],
     series: new Map(),
   });
 
   const [elasticFlamegraph, setElasticFlamegraph] = useState({ leaves: [] });
+  const [elasticFlamegraph2, setElasticFlamegraph2] = useState({ leaves: [] });
   const [pixiFlamegraph, setPixiFlamegraph] = useState({});
 
   const tabs = [
@@ -65,6 +71,19 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
           <EuiSpacer />
           <FlameGraphContext.Provider value={elasticFlamegraph}>
             <FlameGraphNavigation getter={fetchElasticFlamechart} setter={setElasticFlamegraph} />
+            <FlameGraph id="flamechart" height={600} />
+          </FlameGraphContext.Provider>
+        </>
+      ),
+    },
+    {
+      id: 'flamegraph-elastic2',
+      name: 'FlameGraph (Elastic2)',
+      content: (
+        <>
+          <EuiSpacer />
+          <FlameGraphContext.Provider value={elasticFlamegraph2}>
+            <FlameGraphNavigation getter={fetchElasticFlamechart2} setter={setElasticFlamegraph2} />
             <FlameGraph id="flamechart" height={600} />
           </FlameGraphContext.Provider>
         </>

--- a/src/plugins/profiling/public/services.ts
+++ b/src/plugins/profiling/public/services.ts
@@ -12,6 +12,7 @@ import { getRemoteRoutePaths } from '../common';
 export interface Services {
   fetchTopN: (type: string, seconds: string) => Promise<any[] | HttpFetchError>;
   fetchElasticFlamechart: (timeFrom: number, timeTo: number) => Promise<any[] | HttpFetchError>;
+  fetchElasticFlamechart2: (timeFrom: number, timeTo: number) => Promise<any[] | HttpFetchError>;
   fetchPixiFlamechart: (timeFrom: number, timeTo: number) => Promise<any[] | HttpFetchError>;
 }
 
@@ -42,8 +43,24 @@ export function getServices(core: CoreStart): Services {
         const query: HttpFetchQuery = {
           index: 'profiling-events',
           projectID: 5,
-          timeFrom: timeFrom,
-          timeTo: timeTo,
+          timeFrom,
+          timeTo,
+          // TODO remove hard-coded value for topN items length and expose it through the UI
+          n: 100,
+        };
+        return await core.http.get(paths.FlamechartElastic, { query });
+      } catch (e) {
+        return e;
+      }
+    },
+
+    fetchElasticFlamechart2: async (timeFrom: number, timeTo: number) => {
+      try {
+        const query: HttpFetchQuery = {
+          index: 'profiling-events2',
+          projectID: 5,
+          timeFrom,
+          timeTo,
           // TODO remove hard-coded value for topN items length and expose it through the UI
           n: 100,
         };
@@ -58,8 +75,8 @@ export function getServices(core: CoreStart): Services {
         const query: HttpFetchQuery = {
           index: 'profiling-events',
           projectID: 5,
-          timeFrom: timeFrom,
-          timeTo: timeTo,
+          timeFrom,
+          timeTo,
           // TODO remove hard-coded value for topN items length and expose it through the UI
           n: 100,
         };


### PR DESCRIPTION
This PR is only temporary for testing.

It adds another FlameGraph tab in Kibana/prodfiler that queries `profiling-events2*` indices instead of `profiling-events*`. It allows to test different mappings in the MVP cluster (with real data and large amounts of data). Importing enough data locally takes hours or even days and is no longer feasible.

The corresponding change in elastic-collector is https://github.com/elastic/prodfiler/pull/2146. It adds mappings for `profiling-events2*` indices and extends `elastic-collector` to write into these indices in parallel to writing into `profiling-events*`.

The best way to deploy both PRs at once is
- apply the new mappings
- deploy Kibana
- deploy elastic-collector
- reindex from profiling-events* to profiling-events2* (this means copying of all items)