### PR TITLE
Use Elastic date picker for time range

### DIFF
--- a/src/plugins/profiling/public/components/flamegraph-nav.tsx
+++ b/src/plugins/profiling/public/components/flamegraph-nav.tsx
@@ -8,68 +8,99 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { EuiButtonGroup } from '@elastic/eui';
+import dateMath from '@elastic/datemath';
+import { EuiSuperDatePicker } from '@elastic/eui';
+
+interface CommonlyUsedRange {
+  start: string;
+  end: string;
+  label: string;
+}
+
+const commonlyUsedRanges: CommonlyUsedRange[] = [
+  {
+    start: 'now-30m',
+    end: 'now',
+    label: 'Last 30 minutes',
+  },
+  {
+    start: 'now-1h',
+    end: 'now',
+    label: 'Last hour',
+  },
+  {
+    start: 'now-24h',
+    end: 'now',
+    label: 'Last 24 hours',
+  },
+  {
+    start: 'now-1w',
+    end: 'now',
+    label: 'Last 7 days',
+  },
+  {
+    start: 'now-30d',
+    end: 'now',
+    label: 'Last 30 days',
+  },
+];
+
+interface TimeRange {
+  start: string;
+  end: string;
+  isoStart: string;
+  isoEnd: string;
+  unixStart: number;
+  unixEnd: number;
+}
+
+function buildTimeRange(start: string, end: string): TimeRange {
+  const timeStart = dateMath.parse(start);
+  const timeEnd = dateMath.parse(end);
+  return {
+    start,
+    end,
+    isoStart: timeStart.toISOString(),
+    isoEnd: timeEnd.toISOString(),
+    unixStart: timeStart.utc().unix(),
+    unixEnd: timeEnd.utc().unix(),
+  };
+}
 
 export const FlameGraphNavigation = ({ getter, setter }) => {
-  const dateButtonGroupPrefix = 'fgDateButtonGroup';
+  const defaultTimeRange = buildTimeRange(commonlyUsedRanges[0].start, commonlyUsedRanges[0].end);
+  const [timeRange, setTimeRange] = useState(defaultTimeRange);
 
-  const dateButtons = [
-    {
-      id: `${dateButtonGroupPrefix}__0`,
-      label: '30m',
-      value: '1800',
-    },
-    {
-      id: `${dateButtonGroupPrefix}__1`,
-      label: '1h',
-      value: '3600',
-    },
-    {
-      id: `${dateButtonGroupPrefix}__2`,
-      label: '24h',
-      value: '86400',
-    },
-    {
-      id: `${dateButtonGroupPrefix}__3`,
-      label: '7d',
-      value: '604800',
-    },
-    {
-      id: `${dateButtonGroupPrefix}__4`,
-      label: '30d',
-      value: '2592000',
-    },
-  ];
-
-  const [toggleDateSelected, setToggleDateSelected] = useState(`${dateButtonGroupPrefix}__0`);
-
-  const onDateChange = (optionId) => {
-    if (optionId === toggleDateSelected) {
+  const handleTimeChange = (selectedTime: { start: string; end: string; isInvalid: boolean }) => {
+    if (selectedTime.isInvalid) {
       return;
     }
-    setToggleDateSelected(optionId);
+    if (timeRange.start === selectedTime.start && timeRange.end === selectedTime.end) {
+      return;
+    }
+
+    const tr = buildTimeRange(selectedTime.start, selectedTime.end);
+    setTimeRange(tr);
   };
 
   useEffect(() => {
-    const dateValue = dateButtons.filter((button) => {
-      return button.id === toggleDateSelected;
-    });
-
+    console.log(new Date().toISOString(), timeRange);
     console.log(new Date().toISOString(), 'started payload retrieval');
-    getter(dateValue[0].value).then((response) => {
+    getter(timeRange.unixStart, timeRange.unixEnd).then((response) => {
       console.log(new Date().toISOString(), 'finished payload retrieval');
       setter(response);
       console.log(new Date().toISOString(), 'updated local state');
     });
-  }, [toggleDateSelected]);
+  }, [timeRange]);
 
   return (
     <div>
-      <EuiButtonGroup
-        legend="This is a basic group"
-        options={dateButtons}
-        idSelected={toggleDateSelected}
-        onChange={(id) => onDateChange(id)}
+      <EuiSuperDatePicker
+        start={timeRange.start}
+        end={timeRange.end}
+        isPaused={true}
+        onTimeChange={handleTimeChange}
+        commonlyUsedRanges={commonlyUsedRanges}
       />
     </div>
   );

--- a/src/plugins/profiling/public/services.ts
+++ b/src/plugins/profiling/public/services.ts
@@ -11,20 +11,8 @@ import { getRemoteRoutePaths } from '../common';
 
 export interface Services {
   fetchTopN: (type: string, seconds: string) => Promise<any[] | HttpFetchError>;
-  fetchElasticFlamechart: (seconds: string) => Promise<any[] | HttpFetchError>;
-  fetchPixiFlamechart: (seconds: string) => Promise<any[] | HttpFetchError>;
-}
-
-function getFetchQuery(seconds: string): HttpFetchQuery {
-  const unixTime = Math.floor(Date.now() / 1000);
-  return {
-    index: 'profiling-events',
-    projectID: 5,
-    timeFrom: unixTime - parseInt(seconds, 10),
-    timeTo: unixTime,
-    // TODO remove hard-coded value for topN items length and expose it through the UI
-    n: 100,
-  } as HttpFetchQuery;
+  fetchElasticFlamechart: (timeFrom: number, timeTo: number) => Promise<any[] | HttpFetchError>;
+  fetchPixiFlamechart: (timeFrom: number, timeTo: number) => Promise<any[] | HttpFetchError>;
 }
 
 export function getServices(core: CoreStart): Services {
@@ -34,25 +22,47 @@ export function getServices(core: CoreStart): Services {
   return {
     fetchTopN: async (type: string, seconds: string) => {
       try {
-        const query = getFetchQuery(seconds);
+        const unixTime = Math.floor(Date.now() / 1000);
+        const query: HttpFetchQuery = {
+          index: 'profiling-events',
+          projectID: 5,
+          timeFrom: unixTime - parseInt(seconds, 10),
+          timeTo: unixTime,
+          // TODO remove hard-coded value for topN items length and expose it through the UI
+          n: 100,
+        };
         return await core.http.get(`${paths.TopN}/${type}`, { query });
       } catch (e) {
         return e;
       }
     },
 
-    fetchElasticFlamechart: async (seconds: string) => {
+    fetchElasticFlamechart: async (timeFrom: number, timeTo: number) => {
       try {
-        const query = getFetchQuery(seconds);
+        const query: HttpFetchQuery = {
+          index: 'profiling-events',
+          projectID: 5,
+          timeFrom: timeFrom,
+          timeTo: timeTo,
+          // TODO remove hard-coded value for topN items length and expose it through the UI
+          n: 100,
+        };
         return await core.http.get(paths.FlamechartElastic, { query });
       } catch (e) {
         return e;
       }
     },
 
-    fetchPixiFlamechart: async (seconds: string) => {
+    fetchPixiFlamechart: async (timeFrom: number, timeTo: number) => {
       try {
-        const query = getFetchQuery(seconds);
+        const query: HttpFetchQuery = {
+          index: 'profiling-events',
+          projectID: 5,
+          timeFrom: timeFrom,
+          timeTo: timeTo,
+          // TODO remove hard-coded value for topN items length and expose it through the UI
+          n: 100,
+        };
         return await core.http.get(paths.FlamechartPixi, { query });
       } catch (e) {
         return e;


### PR DESCRIPTION
## Summary

This PR updates both flamegraphs to use the Elastic date picker widget when selecting a time range.

The TopN stack traces continue to use the predefined time ranges for now.