### PR TITLE
Allow refresh even if date is unmodified

### DIFF
--- a/src/plugins/profiling/public/components/flamegraph-nav.tsx
+++ b/src/plugins/profiling/public/components/flamegraph-nav.tsx
@@ -75,9 +75,6 @@ export const FlameGraphNavigation = ({ getter, setter }) => {
     if (selectedTime.isInvalid) {
       return;
     }
-    if (timeRange.start === selectedTime.start && timeRange.end === selectedTime.end) {
-      return;
-    }
 
     const tr = buildTimeRange(selectedTime.start, selectedTime.end);
     setTimeRange(tr);


### PR DESCRIPTION
Previously we skipped refreshing the server data if the date value in the datepicker had not changed.