### PR TITLE
Render Pixi flamegraph using Elasticsearch as data source

### DIFF
--- a/src/plugins/profiling/common/callercallee.test.ts
+++ b/src/plugins/profiling/common/callercallee.test.ts
@@ -7,14 +7,14 @@
  */
 
 import {
-  buildCallerCalleeIntermediateNode,
+  createCallerCalleeIntermediateNode,
   fromCallerCalleeIntermediateNode,
 } from './callercallee';
-import { buildStackFrameMetadata, hashFrameGroup } from './profiling';
+import { createStackFrameMetadata, hashFrameGroup } from './profiling';
 
 describe('Caller-callee operations', () => {
   test('1', () => {
-    const parentFrame = buildStackFrameMetadata({
+    const parentFrame = createStackFrameMetadata({
       FileID: '6bc50d345244d5956f93a1b88f41874d',
       FrameType: 3,
       AddressOrLine: 971740,
@@ -24,9 +24,9 @@ describe('Caller-callee operations', () => {
       ExeFileName: 'libc-2.26.so',
       Index: 1,
     });
-    const parent = buildCallerCalleeIntermediateNode(parentFrame, 10);
+    const parent = createCallerCalleeIntermediateNode(parentFrame, 10);
 
-    const childFrame = buildStackFrameMetadata({
+    const childFrame = createStackFrameMetadata({
       FileID: '8d8696a4fd51fa88da70d3fde138247d',
       FrameType: 3,
       AddressOrLine: 67000,
@@ -36,9 +36,9 @@ describe('Caller-callee operations', () => {
       ExeFileName: 'auditd',
       Index: 0,
     });
-    const child = buildCallerCalleeIntermediateNode(childFrame, 10);
+    const child = createCallerCalleeIntermediateNode(childFrame, 10);
 
-    const root = buildCallerCalleeIntermediateNode(buildStackFrameMetadata(), 10);
+    const root = createCallerCalleeIntermediateNode(createStackFrameMetadata(), 10);
     root.callees.set(hashFrameGroup(child.frameGroup), child);
     root.callees.set(hashFrameGroup(parent.frameGroup), parent);
 

--- a/src/plugins/profiling/common/callercallee.test.ts
+++ b/src/plugins/profiling/common/callercallee.test.ts
@@ -21,7 +21,6 @@ describe('Caller-callee operations', () => {
       FunctionName: 'epoll_wait',
       SourceID: 'd670b496cafcaea431a23710fb5e4f58',
       SourceLine: 30,
-      FunctionLine: 27,
       ExeFileName: 'libc-2.26.so',
       Index: 1,
     });
@@ -34,7 +33,6 @@ describe('Caller-callee operations', () => {
       FunctionName: 'epoll_poll',
       SourceID: 'f0a7901dcefed6cc8992a324b9df733c',
       SourceLine: 150,
-      FunctionLine: 139,
       ExeFileName: 'auditd',
       Index: 0,
     });

--- a/src/plugins/profiling/common/callercallee.test.ts
+++ b/src/plugins/profiling/common/callercallee.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  buildCallerCalleeIntermediateNode,
+  fromCallerCalleeIntermediateNode,
+} from './callercallee';
+import { buildStackFrameMetadata, hashFrameGroup } from './profiling';
+
+describe('Caller-callee operations', () => {
+  test('1', () => {
+    const parentFrame = buildStackFrameMetadata({
+      FileID: '6bc50d345244d5956f93a1b88f41874d',
+      FrameType: 3,
+      AddressOrLine: 971740,
+      FunctionName: 'epoll_wait',
+      SourceID: 'd670b496cafcaea431a23710fb5e4f58',
+      SourceLine: 30,
+      FunctionLine: 27,
+      ExeFileName: 'libc-2.26.so',
+      Index: 1,
+    });
+    const parent = buildCallerCalleeIntermediateNode(parentFrame, 10);
+
+    const childFrame = buildStackFrameMetadata({
+      FileID: '8d8696a4fd51fa88da70d3fde138247d',
+      FrameType: 3,
+      AddressOrLine: 67000,
+      FunctionName: 'epoll_poll',
+      SourceID: 'f0a7901dcefed6cc8992a324b9df733c',
+      SourceLine: 150,
+      FunctionLine: 139,
+      ExeFileName: 'auditd',
+      Index: 0,
+    });
+    const child = buildCallerCalleeIntermediateNode(childFrame, 10);
+
+    const root = buildCallerCalleeIntermediateNode(buildStackFrameMetadata(), 10);
+    root.callees.set(hashFrameGroup(child.frameGroup), child);
+    root.callees.set(hashFrameGroup(parent.frameGroup), parent);
+
+    const graph = fromCallerCalleeIntermediateNode(root);
+
+    // Modify original frames to verify graph does not contain references
+    parent.samples = 30;
+    child.samples = 20;
+
+    expect(graph.Callees[0].Samples).toEqual(10);
+    expect(graph.Callees[1].Samples).toEqual(10);
+  });
+});

--- a/src/plugins/profiling/common/callercallee.ts
+++ b/src/plugins/profiling/common/callercallee.ts
@@ -87,7 +87,7 @@ function selectRelevantTraces(
 }
 
 function sortRelevantTraces(relevantTraces: Map<StackTraceID, relevantTrace>): StackTraceID[] {
-  const sortedRelevantTraces: StackTraceID[] = new Array(relevantTraces.size);
+  const sortedRelevantTraces = new Array<StackTraceID>();
   for (const trace of relevantTraces.keys()) {
     sortedRelevantTraces.push(trace);
   }
@@ -220,7 +220,7 @@ function selectCallerCalleeData(frameMetadata: Set<StackFrameMetadata>, node: Ca
 function sortNodes(
   nodes: Map<FrameGroupID, CallerCalleeIntermediateNode>
 ): CallerCalleeIntermediateNode[] {
-  const sortedNodes: CallerCalleeIntermediateNode[] = new Array(nodes.size);
+  const sortedNodes = new Array<CallerCalleeIntermediateNode>();
   for (const node of nodes.values()) {
     sortedNodes.push(node);
   }

--- a/src/plugins/profiling/common/callercallee.ts
+++ b/src/plugins/profiling/common/callercallee.ts
@@ -148,7 +148,7 @@ export function buildCallerCalleeIntermediateRoot(
         node = buildCallerCalleeIntermediateNode(callee, samples);
         currentNode.callees.set(calleeName, node);
       } else {
-        node.samples = samples;
+        node.samples += samples;
       }
       currentNode = node;
     }

--- a/src/plugins/profiling/common/callercallee.ts
+++ b/src/plugins/profiling/common/callercallee.ts
@@ -158,7 +158,6 @@ export function buildCallerCalleeIntermediateRoot(
 export interface CallerCalleeNode {
   Callers: CallerCalleeNode[];
   Callees: CallerCalleeNode[];
-
   FileID: string;
   FrameType: number;
   ExeFileName: string;
@@ -166,13 +165,10 @@ export interface CallerCalleeNode {
   FunctionName: string;
   AddressOrLine: number;
   FunctionSourceLine: number;
-
-  // symbolization fields - currently unused
   FunctionSourceID: string;
   FunctionSourceURL: string;
   SourceFilename: string;
   SourceLine: number;
-
   Samples: number;
 }
 
@@ -201,17 +197,17 @@ export function buildCallerCalleeNode(partial: Partial<CallerCalleeNode> = {}): 
 // one node. It simply takes the data from the first frame.
 function selectCallerCalleeData(frameMetadata: Set<StackFrameMetadata>, node: CallerCalleeNode) {
   for (const metadata of frameMetadata) {
+    node.FileID = metadata.FileID;
+    node.FrameType = metadata.FrameType;
     node.ExeFileName = metadata.ExeFileName;
     node.FunctionID = metadata.FunctionName;
     node.FunctionName = metadata.FunctionName;
+    node.AddressOrLine = metadata.AddressOrLine;
+    node.FunctionSourceLine = metadata.FunctionLine;
     node.FunctionSourceID = metadata.SourceID;
     node.FunctionSourceURL = metadata.SourceCodeURL;
-    node.FunctionSourceLine = metadata.FunctionLine;
-    node.SourceLine = metadata.SourceLine;
-    node.FrameType = metadata.FrameType;
     node.SourceFilename = metadata.SourceFilename;
-    node.FileID = metadata.FileID;
-    node.AddressOrLine = metadata.AddressOrLine;
+    node.SourceLine = metadata.SourceLine;
     break;
   }
 }

--- a/src/plugins/profiling/common/callercallee.ts
+++ b/src/plugins/profiling/common/callercallee.ts
@@ -232,7 +232,7 @@ function sortNodes(
 ): CallerCalleeIntermediateNode[] {
   const sortedNodes = new Array<CallerCalleeIntermediateNode>();
   for (const node of nodes.values()) {
-    sortedNodes.push(clone(node));
+    sortedNodes.push(node);
   }
   return sortedNodes.sort((n1, n2) => {
     return compareFrameGroup(n1.frameGroup, n2.frameGroup);

--- a/src/plugins/profiling/common/callercallee.ts
+++ b/src/plugins/profiling/common/callercallee.ts
@@ -6,7 +6,8 @@
  * Side Public License, v 1.
  */
 
-import { override } from '.';
+import { clone } from 'lodash';
+
 import {
   compareFrameGroup,
   defaultGroupBy,
@@ -175,25 +176,25 @@ export interface CallerCalleeNode {
   Samples: number;
 }
 
-const defaultCallerCalleeNode: CallerCalleeNode = {
-  Callers: [],
-  Callees: [],
-  FileID: '',
-  FrameType: 0,
-  ExeFileName: '',
-  FunctionID: '',
-  FunctionName: '',
-  AddressOrLine: 0,
-  FunctionSourceLine: 0,
-  FunctionSourceID: '',
-  FunctionSourceURL: '',
-  SourceFilename: '',
-  SourceLine: 0,
-  Samples: 0,
-};
+export function buildCallerCalleeNode(partial: Partial<CallerCalleeNode> = {}): CallerCalleeNode {
+  const node = {} as CallerCalleeNode;
 
-export function buildCallerCalleeNode(node: Partial<CallerCalleeNode> = {}): CallerCalleeNode {
-  return override(defaultCallerCalleeNode, node);
+  node.Callers = clone(partial.Callers ?? []);
+  node.Callees = clone(partial.Callees ?? []);
+  node.FileID = partial.FileID ?? '';
+  node.FrameType = partial.FrameType ?? 0;
+  node.ExeFileName = partial.ExeFileName ?? '';
+  node.FunctionID = partial.FunctionID ?? '';
+  node.FunctionName = partial.FunctionName ?? '';
+  node.AddressOrLine = partial.AddressOrLine ?? 0;
+  node.FunctionSourceLine = partial.FunctionSourceLine ?? 0;
+  node.FunctionSourceID = partial.FunctionSourceID ?? '';
+  node.FunctionSourceURL = partial.FunctionSourceURL ?? '';
+  node.SourceFilename = partial.SourceFilename ?? '';
+  node.SourceLine = partial.SourceLine ?? 0;
+  node.Samples = partial.Samples ?? 0;
+
+  return node;
 }
 
 // selectCallerCalleeData is the "standard" way of merging multiple frames into
@@ -220,7 +221,7 @@ function sortNodes(
 ): CallerCalleeIntermediateNode[] {
   const sortedNodes = new Array<CallerCalleeIntermediateNode>();
   for (const node of nodes.values()) {
-    sortedNodes.push(node);
+    sortedNodes.push(clone(node));
   }
   return sortedNodes.sort((n1, n2) => {
     return compareFrameGroup(n1.frameGroup, n2.frameGroup);

--- a/src/plugins/profiling/common/callercallee.ts
+++ b/src/plugins/profiling/common/callercallee.ts
@@ -203,7 +203,21 @@ function selectCallerCalleeData(frameMetadata: Set<StackFrameMetadata>, node: Ca
     node.FunctionID = metadata.FunctionName;
     node.FunctionName = metadata.FunctionName;
     node.AddressOrLine = metadata.AddressOrLine;
-    node.FunctionSourceLine = metadata.FunctionLine;
+
+    // Unknown/invalid offsets are currently set to 0.
+    //
+    // In this case we leave FunctionSourceLine=0 as a flag for the UI that the
+    // FunctionSourceLine should not be displayed.
+    //
+    // As FunctionOffset=0 could also be a legit value, this work-around needs
+    // a real fix. The idea for after GA is to change FunctionOffset=-1 to
+    // indicate unknown/invalid.
+    if (metadata.FunctionOffset > 0) {
+      node.FunctionSourceLine = metadata.SourceLine - metadata.FunctionOffset;
+    } else {
+      node.FunctionSourceLine = 0;
+    }
+
     node.FunctionSourceID = metadata.SourceID;
     node.FunctionSourceURL = metadata.SourceCodeURL;
     node.SourceFilename = metadata.SourceFilename;

--- a/src/plugins/profiling/common/callercallee.ts
+++ b/src/plugins/profiling/common/callercallee.ts
@@ -18,13 +18,13 @@ import {
   StackTraceID,
 } from './profiling';
 
-export interface CallerCalleeIntermediateNode {
+export type CallerCalleeIntermediateNode = {
   frameGroup: FrameGroup;
   callers: Map<FrameGroupID, CallerCalleeIntermediateNode>;
   callees: Map<FrameGroupID, CallerCalleeIntermediateNode>;
   frameMetadata: Set<StackFrameMetadata>;
   samples: number;
-}
+};
 
 export function buildCallerCalleeIntermediateNode(
   frameMetadata: StackFrameMetadata,
@@ -39,10 +39,10 @@ export function buildCallerCalleeIntermediateNode(
   };
 }
 
-interface relevantTrace {
+type relevantTrace = {
   frames: StackFrameMetadata[];
   index: number;
-}
+};
 
 // selectRelevantTraces searches through a map that maps trace hashes to their
 // frames and only returns those traces that have a frame that are equivalent
@@ -155,7 +155,7 @@ export function buildCallerCalleeIntermediateRoot(
   return root;
 }
 
-export interface CallerCalleeNode {
+export type CallerCalleeNode = {
   Callers: CallerCalleeNode[];
   Callees: CallerCalleeNode[];
   FileID: string;
@@ -170,7 +170,7 @@ export interface CallerCalleeNode {
   SourceFilename: string;
   SourceLine: number;
   Samples: number;
-}
+};
 
 export function buildCallerCalleeNode(partial: Partial<CallerCalleeNode> = {}): CallerCalleeNode {
   const node = {} as CallerCalleeNode;

--- a/src/plugins/profiling/common/callercallee.ts
+++ b/src/plugins/profiling/common/callercallee.ts
@@ -138,7 +138,8 @@ export function buildCallerCalleeIntermediateRoot(
     const samples = traces.get(traceHash)!;
 
     // Go through the callees, reverse iteration
-    let currentNode = root;
+    let currentNode = clone(root);
+    root.samples += samples;
     for (let i = callees.length - 1; i >= 0; i--) {
       const callee = callees[i];
       const calleeName = hashFrameGroup(defaultGroupBy(callee));

--- a/src/plugins/profiling/common/callercallee.ts
+++ b/src/plugins/profiling/common/callercallee.ts
@@ -26,18 +26,16 @@ export interface CallerCalleeIntermediateNode {
 }
 
 export function buildCallerCalleeIntermediateNode(
-  frame: StackFrameMetadata,
+  frameMetadata: StackFrameMetadata,
   samples: number
 ): CallerCalleeIntermediateNode {
-  let node: CallerCalleeIntermediateNode = {
-    frameGroup: defaultGroupBy(frame),
+  return {
+    frameGroup: defaultGroupBy(frameMetadata),
     callers: new Map<FrameGroupID, CallerCalleeIntermediateNode>(),
     callees: new Map<FrameGroupID, CallerCalleeIntermediateNode>(),
-    frameMetadata: new Set<StackFrameMetadata>(),
+    frameMetadata: new Set<StackFrameMetadata>([frameMetadata]),
     samples: samples,
   };
-  node.frameMetadata.add(frame);
-  return node;
 }
 
 interface relevantTrace {

--- a/src/plugins/profiling/common/callercallee.ts
+++ b/src/plugins/profiling/common/callercallee.ts
@@ -26,7 +26,7 @@ export type CallerCalleeIntermediateNode = {
   samples: number;
 };
 
-export function buildCallerCalleeIntermediateNode(
+export function createCallerCalleeIntermediateNode(
   frameMetadata: StackFrameMetadata,
   samples: number
 ): CallerCalleeIntermediateNode {
@@ -97,20 +97,20 @@ function sortRelevantTraces(relevantTraces: Map<StackTraceID, relevantTrace>): S
   });
 }
 
-// buildCallerCalleeIntermediateRoot builds a graph in the internal
+// createCallerCalleeIntermediateRoot creates a graph in the internal
 // representation from a StackFrameMetadata that identifies the "centered"
 // function and the trace results that provide traces and the number of times
 // that the trace has been seen.
 //
 // The resulting data structure contains all of the data, but is not yet in the
 // form most easily digestible by others.
-export function buildCallerCalleeIntermediateRoot(
+export function createCallerCalleeIntermediateRoot(
   rootFrame: StackFrameMetadata,
   traces: Map<StackTraceID, number>,
   frames: Map<StackTraceID, StackFrameMetadata[]>
 ): CallerCalleeIntermediateNode {
   // Create a node for the centered frame
-  const root = buildCallerCalleeIntermediateNode(rootFrame, 0);
+  const root = createCallerCalleeIntermediateNode(rootFrame, 0);
 
   // Obtain only the relevant frames (e.g. frames that contain the root frame
   // somewhere). If the root frame is "empty" (e.g. fileID is zero and line
@@ -145,7 +145,7 @@ export function buildCallerCalleeIntermediateRoot(
       const calleeName = hashFrameGroup(defaultGroupBy(callee));
       let node = currentNode.callees.get(calleeName);
       if (node === undefined) {
-        node = buildCallerCalleeIntermediateNode(callee, samples);
+        node = createCallerCalleeIntermediateNode(callee, samples);
         currentNode.callees.set(calleeName, node);
       } else {
         node.samples += samples;
@@ -173,23 +173,23 @@ export type CallerCalleeNode = {
   Samples: number;
 };
 
-export function buildCallerCalleeNode(partial: Partial<CallerCalleeNode> = {}): CallerCalleeNode {
+export function createCallerCalleeNode(options: Partial<CallerCalleeNode> = {}): CallerCalleeNode {
   const node = {} as CallerCalleeNode;
 
-  node.Callers = clone(partial.Callers ?? []);
-  node.Callees = clone(partial.Callees ?? []);
-  node.FileID = partial.FileID ?? '';
-  node.FrameType = partial.FrameType ?? 0;
-  node.ExeFileName = partial.ExeFileName ?? '';
-  node.FunctionID = partial.FunctionID ?? '';
-  node.FunctionName = partial.FunctionName ?? '';
-  node.AddressOrLine = partial.AddressOrLine ?? 0;
-  node.FunctionSourceLine = partial.FunctionSourceLine ?? 0;
-  node.FunctionSourceID = partial.FunctionSourceID ?? '';
-  node.FunctionSourceURL = partial.FunctionSourceURL ?? '';
-  node.SourceFilename = partial.SourceFilename ?? '';
-  node.SourceLine = partial.SourceLine ?? 0;
-  node.Samples = partial.Samples ?? 0;
+  node.Callers = clone(options.Callers ?? []);
+  node.Callees = clone(options.Callees ?? []);
+  node.FileID = options.FileID ?? '';
+  node.FrameType = options.FrameType ?? 0;
+  node.ExeFileName = options.ExeFileName ?? '';
+  node.FunctionID = options.FunctionID ?? '';
+  node.FunctionName = options.FunctionName ?? '';
+  node.AddressOrLine = options.AddressOrLine ?? 0;
+  node.FunctionSourceLine = options.FunctionSourceLine ?? 0;
+  node.FunctionSourceID = options.FunctionSourceID ?? '';
+  node.FunctionSourceURL = options.FunctionSourceURL ?? '';
+  node.SourceFilename = options.SourceFilename ?? '';
+  node.SourceLine = options.SourceLine ?? 0;
+  node.Samples = options.Samples ?? 0;
 
   return node;
 }
@@ -245,7 +245,7 @@ function sortNodes(
 export function fromCallerCalleeIntermediateNode(
   root: CallerCalleeIntermediateNode
 ): CallerCalleeNode {
-  const node = buildCallerCalleeNode({ Samples: root.samples });
+  const node = createCallerCalleeNode({ Samples: root.samples });
 
   // Populate the other fields with data from the root node. Selectors are not supposed
   // to be able to fail.

--- a/src/plugins/profiling/common/flamegraph.ts
+++ b/src/plugins/profiling/common/flamegraph.ts
@@ -85,7 +85,7 @@ export class FlameGraph {
       const frameMetadata = new Array<StackFrameMetadata>();
       for (let i = 0; i < trace.FrameID.length; i++) {
         const metadata = buildStackFrameMetadata({ Index: i });
-        metadata.FileID = trace.FileID[i];
+        metadata.FileID = Buffer.from(trace.FileID[i], 'base64url').toString('hex');
         metadata.FrameType = trace.Type[i];
 
         const frame = this.stackframes.get(trace.FrameID[i])!;

--- a/src/plugins/profiling/common/flamegraph.ts
+++ b/src/plugins/profiling/common/flamegraph.ts
@@ -84,18 +84,19 @@ export class FlameGraph {
     for (const [stackTraceID, trace] of this.stacktraces) {
       const frameMetadata = new Array<StackFrameMetadata>();
       for (let i = 0; i < trace.FrameID.length; i++) {
-        const metadata = createStackFrameMetadata({ Index: i });
-        metadata.FileID = Buffer.from(trace.FileID[i], 'base64url').toString('hex');
-        metadata.FrameType = trace.Type[i];
-
         const frame = this.stackframes.get(trace.FrameID[i])!;
-        metadata.AddressOrLine = frame.LineNumber;
-        metadata.FunctionName = frame.FunctionName;
-        metadata.FunctionOffset = frame.FunctionOffset;
-        metadata.SourceLine = frame.LineNumber;
-
         const executable = this.executables.get(trace.FileID[i])!;
-        metadata.ExeFileName = executable.FileName;
+
+        const metadata = createStackFrameMetadata({
+          FileID: Buffer.from(trace.FileID[i], 'base64url').toString('hex'),
+          FrameType: trace.Type[i],
+          AddressOrLine: frame.LineNumber,
+          FunctionName: frame.FunctionName,
+          FunctionOffset: frame.FunctionOffset,
+          SourceLine: frame.LineNumber,
+          ExeFileName: executable.FileName,
+          Index: i,
+        });
 
         frameMetadata.push(metadata);
       }

--- a/src/plugins/profiling/common/flamegraph.ts
+++ b/src/plugins/profiling/common/flamegraph.ts
@@ -31,7 +31,7 @@ function checkIfStringHasParentheses(s: string) {
   return /\(|\)/.test(s);
 }
 
-function getFunctionName(frame: any) {
+function getFunctionName(frame: StackFrame) {
   return frame.FunctionName !== '' && !checkIfStringHasParentheses(frame.FunctionName)
     ? `${frame.FunctionName}()`
     : frame.FunctionName;
@@ -110,7 +110,7 @@ export class FlameGraph {
   // Generates the label for a flamegraph node
   //
   // This is slightly modified from the original code in elastic/prodfiler_ui
-  private getLabel(frame: any, executable: any, type: number) {
+  private getLabel(frame: StackFrame, executable: Executable, type: number) {
     if (frame.FunctionName !== '') {
       return `${this.getExeFileName(executable, type)}: ${getFunctionName(frame)} in #${
         frame.LineNumber
@@ -127,9 +127,9 @@ export class FlameGraph {
       const path = ['root'];
       for (let i = 0; i < trace.FrameID.length; i++) {
         const label = this.getLabel(
-          this.stackframes.get(trace.FrameID[i]),
-          this.executables.get(trace.FileID[i]),
-          parseInt(trace.Type[i], 10)
+          this.stackframes.get(trace.FrameID[i])!,
+          this.executables.get(trace.FileID[i])!,
+          trace.Type[i]
         );
 
         if (label.length === 0) {

--- a/src/plugins/profiling/common/flamegraph.ts
+++ b/src/plugins/profiling/common/flamegraph.ts
@@ -7,8 +7,8 @@
  */
 import { Logger } from 'kibana/server';
 import {
-  buildCallerCalleeIntermediateRoot,
   CallerCalleeNode,
+  createCallerCalleeIntermediateRoot,
   fromCallerCalleeIntermediateNode,
 } from './callercallee';
 import {
@@ -18,7 +18,7 @@ import {
   StackTrace,
   StackFrame,
   Executable,
-  buildStackFrameMetadata,
+  createStackFrameMetadata,
   StackFrameMetadata,
 } from './profiling';
 
@@ -84,7 +84,7 @@ export class FlameGraph {
     for (const [stackTraceID, trace] of this.stacktraces) {
       const frameMetadata = new Array<StackFrameMetadata>();
       for (let i = 0; i < trace.FrameID.length; i++) {
-        const metadata = buildStackFrameMetadata({ Index: i });
+        const metadata = createStackFrameMetadata({ Index: i });
         metadata.FileID = Buffer.from(trace.FileID[i], 'base64url').toString('hex');
         metadata.FrameType = trace.Type[i];
 
@@ -186,9 +186,9 @@ export class FlameGraph {
   }
 
   toPixi(): PixiFlameGraph {
-    const rootFrame = buildStackFrameMetadata();
+    const rootFrame = createStackFrameMetadata();
     const frameMetadataForTraces = this.getFrameMetadataForTraces();
-    const diagram = buildCallerCalleeIntermediateRoot(
+    const diagram = createCallerCalleeIntermediateRoot(
       rootFrame,
       this.events,
       frameMetadataForTraces

--- a/src/plugins/profiling/common/index.ts
+++ b/src/plugins/profiling/common/index.ts
@@ -40,13 +40,6 @@ export function getRemoteRoutePaths() {
   };
 }
 
-// override combines the template object and the overrides to produce a new
-// object. Any missing properties from the partial object will be set by the
-// template object.
-export function override<T>(template: T, overrides: Partial<T>): T {
-  return { ...template, ...overrides };
-}
-
 function toMilliseconds(seconds: string): number {
   return parseInt(seconds, 10) * 1000;
 }

--- a/src/plugins/profiling/common/profiling.test.ts
+++ b/src/plugins/profiling/common/profiling.test.ts
@@ -7,8 +7,8 @@
  */
 
 import {
-  buildFrameGroup,
-  buildStackFrameMetadata,
+  createFrameGroup,
+  createStackFrameMetadata,
   compareFrameGroup,
   defaultGroupBy,
   hashFrameGroup,
@@ -16,25 +16,25 @@ import {
 
 describe('Frame group operations', () => {
   test('check if a frame group is less than another', () => {
-    const a = buildFrameGroup({ ExeFileName: 'chrome' });
-    const b = buildFrameGroup({ ExeFileName: 'dockerd' });
+    const a = createFrameGroup({ ExeFileName: 'chrome' });
+    const b = createFrameGroup({ ExeFileName: 'dockerd' });
     expect(compareFrameGroup(a, b)).toEqual(-1);
   });
 
   test('check if a frame group is greater than another', () => {
-    const a = buildFrameGroup({ ExeFileName: 'oom_reaper' });
-    const b = buildFrameGroup({ ExeFileName: 'dockerd' });
+    const a = createFrameGroup({ ExeFileName: 'oom_reaper' });
+    const b = createFrameGroup({ ExeFileName: 'dockerd' });
     expect(compareFrameGroup(a, b)).toEqual(1);
   });
 
   test('check if frame groups are equal', () => {
-    const a = buildFrameGroup({ AddressOrLine: 1234 });
-    const b = buildFrameGroup({ AddressOrLine: 1234 });
+    const a = createFrameGroup({ AddressOrLine: 1234 });
+    const b = createFrameGroup({ AddressOrLine: 1234 });
     expect(compareFrameGroup(a, b)).toEqual(0);
   });
 
   test('check serialized non-symbolized frame', () => {
-    const metadata = buildStackFrameMetadata({
+    const metadata = createStackFrameMetadata({
       FileID: '0x0123456789ABCDEF',
       AddressOrLine: 102938,
     });
@@ -44,7 +44,7 @@ describe('Frame group operations', () => {
   });
 
   test('check serialized non-symbolized ELF frame', () => {
-    const metadata = buildStackFrameMetadata({
+    const metadata = createStackFrameMetadata({
       FunctionName: 'strlen()',
       FileID: '0x0123456789ABCDEF',
     });
@@ -54,7 +54,7 @@ describe('Frame group operations', () => {
   });
 
   test('check serialized symbolized frame', () => {
-    const metadata = buildStackFrameMetadata({
+    const metadata = createStackFrameMetadata({
       ExeFileName: 'chrome',
       SourceFilename: 'strlen()',
       FunctionName: 'strlen()',

--- a/src/plugins/profiling/common/profiling.test.ts
+++ b/src/plugins/profiling/common/profiling.test.ts
@@ -11,6 +11,7 @@ import {
   buildStackFrameMetadata,
   compareFrameGroup,
   defaultGroupBy,
+  hashFrameGroup,
 } from './profiling';
 
 describe('Frame group operations', () => {
@@ -37,7 +38,7 @@ describe('Frame group operations', () => {
       FileID: '0x0123456789ABCDEF',
       AddressOrLine: 102938,
     });
-    expect(defaultGroupBy(metadata)).toEqual(
+    expect(hashFrameGroup(defaultGroupBy(metadata))).toEqual(
       '{"FileID":"0x0123456789ABCDEF","ExeFileName":"","FunctionName":"","AddressOrLine":102938,"SourceFilename":""}'
     );
   });
@@ -47,7 +48,7 @@ describe('Frame group operations', () => {
       FunctionName: 'strlen()',
       FileID: '0x0123456789ABCDEF',
     });
-    expect(defaultGroupBy(metadata)).toEqual(
+    expect(hashFrameGroup(defaultGroupBy(metadata))).toEqual(
       '{"FileID":"0x0123456789ABCDEF","ExeFileName":"","FunctionName":"strlen()","AddressOrLine":0,"SourceFilename":""}'
     );
   });
@@ -58,7 +59,7 @@ describe('Frame group operations', () => {
       SourceFilename: 'strlen()',
       FunctionName: 'strlen()',
     });
-    expect(defaultGroupBy(metadata)).toEqual(
+    expect(hashFrameGroup(defaultGroupBy(metadata))).toEqual(
       '{"FileID":"","ExeFileName":"chrome","FunctionName":"strlen()","AddressOrLine":0,"SourceFilename":"strlen()"}'
     );
   });

--- a/src/plugins/profiling/common/profiling.ts
+++ b/src/plugins/profiling/common/profiling.ts
@@ -152,15 +152,13 @@ export function compareFrameGroup(a: FrameGroup, b: FrameGroup): number {
   return 0;
 }
 
-export type FrameGroupID = string;
-
 // defaultGroupBy is the "standard" way of grouping frames, by commonly
 // shared group identifiers.
 //
 // For ELF-symbolized frames, group by FunctionName and FileID.
 // For non-symbolized frames, group by FileID and AddressOrLine.
 // Otherwise group by ExeFileName, SourceFilename and FunctionName.
-export function defaultGroupBy(frame: StackFrameMetadata): FrameGroupID {
+export function defaultGroupBy(frame: StackFrameMetadata): FrameGroup {
   const frameGroup = buildFrameGroup();
 
   if (frame.FunctionName === '') {
@@ -178,6 +176,12 @@ export function defaultGroupBy(frame: StackFrameMetadata): FrameGroupID {
     frameGroup.FunctionName = frame.FunctionName;
   }
 
-  // We serialize to JSON string to use FrameGroup as a key
+  return frameGroup;
+}
+
+export type FrameGroupID = string;
+
+export function hashFrameGroup(frameGroup: FrameGroup): FrameGroupID {
+  // We use serialized JSON as the unique value of a frame group for now
   return JSON.stringify(frameGroup);
 }

--- a/src/plugins/profiling/common/profiling.ts
+++ b/src/plugins/profiling/common/profiling.ts
@@ -6,8 +6,6 @@
  * Side Public License, v 1.
  */
 
-import { override } from '.';
-
 export type StackTraceID = string;
 export type StackFrameID = string;
 export type FileID = string;
@@ -88,35 +86,30 @@ export type StackFrameMetadata = {
   Index: number;
 };
 
-const defaultStackFrameMetadata: StackFrameMetadata = {
-  FileID: '',
-  FrameType: 0,
-  FrameTypeString: '',
-
-  AddressOrLine: 0,
-  FunctionName: '',
-  FunctionOffset: 0,
-  SourceID: '',
-  SourceLine: 0,
-
-  FunctionLine: 0,
-
-  ExeFileName: '',
-
-  CommitHash: '',
-  SourceCodeURL: '',
-  SourceFilename: '',
-  SourcePackageHash: '',
-  SourcePackageURL: '',
-  SourceType: 0,
-
-  Index: 0,
-};
-
 export function buildStackFrameMetadata(
-  metadata: Partial<StackFrameMetadata> = {}
+  partial: Partial<StackFrameMetadata> = {}
 ): StackFrameMetadata {
-  return override(defaultStackFrameMetadata, metadata);
+  const metadata = {} as StackFrameMetadata;
+
+  metadata.FileID = partial.FileID ?? '';
+  metadata.FrameType = partial.FrameType ?? 0;
+  metadata.FrameTypeString = partial.FrameTypeString ?? '';
+  metadata.AddressOrLine = partial.AddressOrLine ?? 0;
+  metadata.FunctionName = partial.FunctionName ?? '';
+  metadata.FunctionOffset = partial.FunctionOffset ?? 0;
+  metadata.SourceID = partial.SourceID ?? '';
+  metadata.SourceLine = partial.SourceLine ?? 0;
+  metadata.FunctionLine = partial.FunctionLine ?? 0;
+  metadata.ExeFileName = partial.ExeFileName ?? '';
+  metadata.CommitHash = partial.CommitHash ?? '';
+  metadata.SourceCodeURL = partial.SourceCodeURL ?? '';
+  metadata.SourceFilename = partial.SourceFilename ?? '';
+  metadata.SourcePackageHash = partial.SourcePackageHash ?? '';
+  metadata.SourcePackageURL = partial.SourcePackageURL ?? '';
+  metadata.SourceType = partial.SourceType ?? 0;
+  metadata.Index = partial.Index ?? 0;
+
+  return metadata;
 }
 
 export type FrameGroup = Pick<
@@ -124,18 +117,18 @@ export type FrameGroup = Pick<
   'FileID' | 'ExeFileName' | 'FunctionName' | 'AddressOrLine' | 'SourceFilename'
 >;
 
-const defaultFrameGroup: FrameGroup = {
-  FileID: '',
-  ExeFileName: '',
-  FunctionName: '',
-  AddressOrLine: 0,
-  SourceFilename: '',
-};
-
 // This is a convenience function to build a FrameGroup value with
 // defaults for missing fields
-export function buildFrameGroup(frameGroup: Partial<FrameGroup> = {}): FrameGroup {
-  return override(defaultFrameGroup, frameGroup);
+export function buildFrameGroup(partial: Partial<FrameGroup> = {}): FrameGroup {
+  const frameGroup = {} as FrameGroup;
+
+  frameGroup.FileID = partial.FileID ?? '';
+  frameGroup.ExeFileName = partial.ExeFileName ?? '';
+  frameGroup.FunctionName = partial.FunctionName ?? '';
+  frameGroup.AddressOrLine = partial.AddressOrLine ?? 0;
+  frameGroup.SourceFilename = partial.SourceFilename ?? '';
+
+  return frameGroup;
 }
 
 export function compareFrameGroup(a: FrameGroup, b: FrameGroup): number {

--- a/src/plugins/profiling/common/profiling.ts
+++ b/src/plugins/profiling/common/profiling.ts
@@ -10,16 +10,16 @@ export type StackTraceID = string;
 export type StackFrameID = string;
 export type FileID = string;
 
-export interface StackTraceEvent {
+export type StackTraceEvent = {
   StackTraceID: StackTraceID;
   Count: number;
-}
+};
 
-export interface StackTrace {
+export type StackTrace = {
   FileID: string[];
   FrameID: string[];
   Type: number[];
-}
+};
 
 export type StackFrame = {
   FileName: string;
@@ -29,9 +29,9 @@ export type StackFrame = {
   SourceType: number;
 };
 
-export interface Executable {
+export type Executable = {
   FileName: string;
-}
+};
 
 export type StackFrameMetadata = {
   // StackTrace.FileID

--- a/src/plugins/profiling/common/profiling.ts
+++ b/src/plugins/profiling/common/profiling.ts
@@ -71,27 +71,27 @@ export type StackFrameMetadata = {
   Index: number;
 };
 
-export function buildStackFrameMetadata(
-  partial: Partial<StackFrameMetadata> = {}
+export function createStackFrameMetadata(
+  options: Partial<StackFrameMetadata> = {}
 ): StackFrameMetadata {
   const metadata = {} as StackFrameMetadata;
 
-  metadata.FileID = partial.FileID ?? '';
-  metadata.FrameType = partial.FrameType ?? 0;
-  metadata.FrameTypeString = partial.FrameTypeString ?? '';
-  metadata.AddressOrLine = partial.AddressOrLine ?? 0;
-  metadata.FunctionName = partial.FunctionName ?? '';
-  metadata.FunctionOffset = partial.FunctionOffset ?? 0;
-  metadata.SourceID = partial.SourceID ?? '';
-  metadata.SourceLine = partial.SourceLine ?? 0;
-  metadata.ExeFileName = partial.ExeFileName ?? '';
-  metadata.CommitHash = partial.CommitHash ?? '';
-  metadata.SourceCodeURL = partial.SourceCodeURL ?? '';
-  metadata.SourceFilename = partial.SourceFilename ?? '';
-  metadata.SourcePackageHash = partial.SourcePackageHash ?? '';
-  metadata.SourcePackageURL = partial.SourcePackageURL ?? '';
-  metadata.SourceType = partial.SourceType ?? 0;
-  metadata.Index = partial.Index ?? 0;
+  metadata.FileID = options.FileID ?? '';
+  metadata.FrameType = options.FrameType ?? 0;
+  metadata.FrameTypeString = options.FrameTypeString ?? '';
+  metadata.AddressOrLine = options.AddressOrLine ?? 0;
+  metadata.FunctionName = options.FunctionName ?? '';
+  metadata.FunctionOffset = options.FunctionOffset ?? 0;
+  metadata.SourceID = options.SourceID ?? '';
+  metadata.SourceLine = options.SourceLine ?? 0;
+  metadata.ExeFileName = options.ExeFileName ?? '';
+  metadata.CommitHash = options.CommitHash ?? '';
+  metadata.SourceCodeURL = options.SourceCodeURL ?? '';
+  metadata.SourceFilename = options.SourceFilename ?? '';
+  metadata.SourcePackageHash = options.SourcePackageHash ?? '';
+  metadata.SourcePackageURL = options.SourcePackageURL ?? '';
+  metadata.SourceType = options.SourceType ?? 0;
+  metadata.Index = options.Index ?? 0;
 
   return metadata;
 }
@@ -101,16 +101,16 @@ export type FrameGroup = Pick<
   'FileID' | 'ExeFileName' | 'FunctionName' | 'AddressOrLine' | 'SourceFilename'
 >;
 
-// This is a convenience function to build a FrameGroup value with
+// This is a convenience function to create a FrameGroup value with
 // defaults for missing fields
-export function buildFrameGroup(partial: Partial<FrameGroup> = {}): FrameGroup {
+export function createFrameGroup(options: Partial<FrameGroup> = {}): FrameGroup {
   const frameGroup = {} as FrameGroup;
 
-  frameGroup.FileID = partial.FileID ?? '';
-  frameGroup.ExeFileName = partial.ExeFileName ?? '';
-  frameGroup.FunctionName = partial.FunctionName ?? '';
-  frameGroup.AddressOrLine = partial.AddressOrLine ?? 0;
-  frameGroup.SourceFilename = partial.SourceFilename ?? '';
+  frameGroup.FileID = options.FileID ?? '';
+  frameGroup.ExeFileName = options.ExeFileName ?? '';
+  frameGroup.FunctionName = options.FunctionName ?? '';
+  frameGroup.AddressOrLine = options.AddressOrLine ?? 0;
+  frameGroup.SourceFilename = options.SourceFilename ?? '';
 
   return frameGroup;
 }
@@ -136,7 +136,7 @@ export function compareFrameGroup(a: FrameGroup, b: FrameGroup): number {
 // For non-symbolized frames, group by FileID and AddressOrLine.
 // Otherwise group by ExeFileName, SourceFilename and FunctionName.
 export function defaultGroupBy(frame: StackFrameMetadata): FrameGroup {
-  const frameGroup = buildFrameGroup();
+  const frameGroup = createFrameGroup();
 
   if (frame.FunctionName === '') {
     // Non-symbolized frame where we only have FileID and AddressOrLine

--- a/src/plugins/profiling/common/profiling.ts
+++ b/src/plugins/profiling/common/profiling.ts
@@ -52,21 +52,6 @@ export type StackFrameMetadata = {
   // StackFrame.LineNumber
   SourceLine: number;
 
-  // value defined by:
-  //   if StackFrame.FunctionOffset > 0:
-  //     StackFrame.LineNumber - StackFrame.FunctionOffset
-  //   else:
-  //     0
-  //
-  // Unknown/invalid offsets are currently set to 0.
-  //
-  // In this case we leave FunctionLine=0 as a flag for the UI that the
-  // FunctionLine should not be displayed.
-  //
-  // As offset=0 could also be a legit value, this work-around needs a real fix.
-  // The idea for after GA is to change offset=-1 to indicate unknown/invalid.
-  FunctionLine: number;
-
   // Executable.FileName
   ExeFileName: string;
 
@@ -99,7 +84,6 @@ export function buildStackFrameMetadata(
   metadata.FunctionOffset = partial.FunctionOffset ?? 0;
   metadata.SourceID = partial.SourceID ?? '';
   metadata.SourceLine = partial.SourceLine ?? 0;
-  metadata.FunctionLine = partial.FunctionLine ?? 0;
   metadata.ExeFileName = partial.ExeFileName ?? '';
   metadata.CommitHash = partial.CommitHash ?? '';
   metadata.SourceCodeURL = partial.SourceCodeURL ?? '';

--- a/src/plugins/profiling/common/profiling.ts
+++ b/src/plugins/profiling/common/profiling.ts
@@ -20,7 +20,7 @@ export interface StackTraceEvent {
 export interface StackTrace {
   FileID: string[];
   FrameID: string[];
-  Type: string[];
+  Type: number[];
 }
 
 export type StackFrame = {

--- a/src/plugins/profiling/common/profiling.ts
+++ b/src/plugins/profiling/common/profiling.ts
@@ -31,56 +31,92 @@ export type StackFrame = {
   SourceType: number;
 };
 
+export interface Executable {
+  FileName: string;
+}
+
 export type StackFrameMetadata = {
+  // StackTrace.FileID
   FileID: FileID;
-  AddressOrLine: number;
-
-  FunctionName: string;
-  SourceID: FileID;
-  SourceLine: number;
-  FunctionOffset: number;
-
-  CommitHash: string;
-  SourceCodeURL: string;
-  SourcePackageHash: string;
-  FrameTypeString: string;
-  SourceFilename: string;
-  ExeFileName: string;
-  SourcePackageURL: string;
+  // StackTrace.Type
   FrameType: number;
+  // stringified FrameType -- FrameType.String()
+  FrameTypeString: string;
+
+  // StackFrame.LineNumber?
+  AddressOrLine: number;
+  // StackFrame.FunctionName
+  FunctionName: string;
+  // StackFrame.FunctionOffset
+  FunctionOffset: number;
+  // should this be StackFrame.SourceID?
+  SourceID: FileID;
+  // StackFrame.LineNumber
+  SourceLine: number;
+
+  // value defined by:
+  //   if StackFrame.FunctionOffset > 0:
+  //     StackFrame.LineNumber - StackFrame.FunctionOffset
+  //   else:
+  //     0
+  //
+  // Unknown/invalid offsets are currently set to 0.
+  //
+  // In this case we leave FunctionLine=0 as a flag for the UI that the
+  // FunctionLine should not be displayed.
+  //
+  // As offset=0 could also be a legit value, this work-around needs a real fix.
+  // The idea for after GA is to change offset=-1 to indicate unknown/invalid.
   FunctionLine: number;
+
+  // Executable.FileName
+  ExeFileName: string;
+
+  // unused atm due to lack of symbolization metadata
+  CommitHash: string;
+  // unused atm due to lack of symbolization metadata
+  SourceCodeURL: string;
+  // unused atm due to lack of symbolization metadata
+  SourceFilename: string;
+  // unused atm due to lack of symbolization metadata
+  SourcePackageHash: string;
+  // unused atm due to lack of symbolization metadata
+  SourcePackageURL: string;
+  // unused atm due to lack of symbolization metadata
   SourceType: number;
+
+  Index: number;
 };
 
 const defaultStackFrameMetadata: StackFrameMetadata = {
   FileID: '',
-  AddressOrLine: 0,
+  FrameType: 0,
+  FrameTypeString: '',
 
+  AddressOrLine: 0,
   FunctionName: '',
+  FunctionOffset: 0,
   SourceID: '',
   SourceLine: 0,
-  FunctionOffset: 0,
+
+  FunctionLine: 0,
+
+  ExeFileName: '',
 
   CommitHash: '',
   SourceCodeURL: '',
-  SourcePackageHash: '',
-  FrameTypeString: '',
   SourceFilename: '',
-  ExeFileName: '',
+  SourcePackageHash: '',
   SourcePackageURL: '',
-  FrameType: 0,
-  FunctionLine: 0,
   SourceType: 0,
+
+  Index: 0,
 };
 
 export function buildStackFrameMetadata(
   metadata: Partial<StackFrameMetadata> = {}
 ): StackFrameMetadata {
   return override(defaultStackFrameMetadata, metadata);
-}
-
-export interface Executable {
-  FileName: string;
 }
 
 export type FrameGroup = Pick<


### PR DESCRIPTION
This PR ports enough of the web service functionality so that we connect the Pixi flamegraph to Elasticsearch as a data source.

![image](https://user-images.githubusercontent.com/6038/159598500-1754ef06-a2bc-44d2-8c73-bda710d771ad.png)

See https://github.com/elastic/prodfiler/issues/2038