### PR TITLE
update indices names with data streams aliases

### DIFF
--- a/src/plugins/profiling/public/services.ts
+++ b/src/plugins/profiling/public/services.ts
@@ -25,7 +25,7 @@ export function getServices(core: CoreStart): Services {
       try {
         const unixTime = Math.floor(Date.now() / 1000);
         const query: HttpFetchQuery = {
-          index: 'profiling-events',
+          index: 'profiling-events-all',
           projectID: 5,
           timeFrom: unixTime - parseInt(seconds, 10),
           timeTo: unixTime,
@@ -41,7 +41,7 @@ export function getServices(core: CoreStart): Services {
     fetchElasticFlamechart: async (timeFrom: number, timeTo: number) => {
       try {
         const query: HttpFetchQuery = {
-          index: 'profiling-events',
+          index: 'profiling-events-all',
           projectID: 5,
           timeFrom,
           timeTo,
@@ -73,7 +73,7 @@ export function getServices(core: CoreStart): Services {
     fetchPixiFlamechart: async (timeFrom: number, timeTo: number) => {
       try {
         const query: HttpFetchQuery = {
-          index: 'profiling-events',
+          index: 'profiling-events-all',
           projectID: 5,
           timeFrom,
           timeTo,

--- a/src/plugins/profiling/scripts/export_from_testing.sh
+++ b/src/plugins/profiling/scripts/export_from_testing.sh
@@ -46,18 +46,18 @@ export_events() {
     "bool": {
       "filter": [
         {
-          "term": { 
+          "term": {
             "ProjectID": 5
-          }                       
-        },                       
-        {                             
+          }
+        },
+        {
           "range": {
             "@timestamp": {
               "gte": "'"$from"'",
               "lt": "'"$to"'",
               "format": "epoch_second"
             }
-          }                                                
+          }
         }
       ]
     }
@@ -104,11 +104,11 @@ done
 docker pull elasticdump/elasticsearch-dump:latest
 
 # Export full events table
-export_events "profiling-events" "$date_from" "$date_to"
+export_events "profiling-events-all" "$date_from" "$date_to"
 
 # Export down-sampled tables
 for ((i = 1; i <= 11; i++)); do
-  export_events "profiling-events-5pow$i" "$date_from" "$date_to"
+  export_events "profiling-events-5pow$(printf '%02d' i)" "$date_from" "$date_to"
 done
 
 # We need all stacktraces, stackframes and executables as 'LastSeen' may be outside [date_from, date_to].

--- a/src/plugins/profiling/server/routes/search_flamechart.test.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.test.ts
@@ -23,27 +23,27 @@ describe('Using down-sampled indexes', () => {
       {
         // stay with the input downsampled index
         sampleCountFromPow6: targetSampleSize,
-        expected: { name: 'profiling-events-5pow6', sampleRate: 1 / 5 ** 6 },
+        expected: { name: 'profiling-events-5pow06', sampleRate: 1 / 5 ** 6 },
       },
       {
         // stay with the input downsampled index
         sampleCountFromPow6: targetSampleSize * 5 - 1,
-        expected: { name: 'profiling-events-5pow6', sampleRate: 1 / 5 ** 6 },
+        expected: { name: 'profiling-events-5pow06', sampleRate: 1 / 5 ** 6 },
       },
       {
         // go down one downsampling step
         sampleCountFromPow6: targetSampleSize * 5,
-        expected: { name: 'profiling-events-5pow7', sampleRate: 1 / 5 ** 7 },
+        expected: { name: 'profiling-events-5pow07', sampleRate: 1 / 5 ** 7 },
       },
       {
         // go up one downsampling step
         sampleCountFromPow6: targetSampleSize - 1,
-        expected: { name: 'profiling-events-5pow5', sampleRate: 1 / 5 ** 5 },
+        expected: { name: 'profiling-events-5pow05', sampleRate: 1 / 5 ** 5 },
       },
       {
         // go to the full events index
         sampleCountFromPow6: 0,
-        expected: { name: 'profiling-events', sampleRate: 1 },
+        expected: { name: 'profiling-events-all', sampleRate: 1 },
       },
       {
         // go to the most downsampled index
@@ -54,7 +54,12 @@ describe('Using down-sampled indexes', () => {
 
     for (const t of tests) {
       expect(
-        getSampledTraceEventsIndex(targetSampleSize, t.sampleCountFromPow6, initialExp)
+        getSampledTraceEventsIndex(
+          'profiling-events-all',
+          targetSampleSize,
+          t.sampleCountFromPow6,
+          initialExp
+        )
       ).toEqual(t.expected);
     }
   });


### PR DESCRIPTION
## Summary

We introduce data streams with https://github.com/elastic/prodfiler/pull/2017/files in the backend.
With that, names for the indices have changed and update them here.

**NOTE** @rockdaboot this breaks the `2` suffix indices browsing in the additional tab.
What should we do with it?
