### PR TITLE
Split mget into 4 parallel queries

### DIFF
--- a/src/plugins/profiling/server/routes/search_flamechart.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.ts
@@ -271,71 +271,87 @@ async function queryFlameGraph(
     logger.info('unique downsampled stacktraces: ' + stackTraceEvents.size);
   }
 
-  const resStackTraces = await logExecutionLatency(
+  const nQueries = 4;
+  const results = new Array(nQueries);
+
+  await logExecutionLatency(
     logger,
     'mget query for ' + stackTraceEvents.size + ' stacktraces',
     async () => {
-      if (testing) {
-        return await client.search(
-          {
+      const promises = new Array(nQueries);
+      const chunkSize = Math.floor(stackTraceEvents.size / nQueries);
+      const stackTraceIDs = [...stackTraceEvents.keys()];
+
+      logger.info('A');
+
+      for (let i = 0; i < nQueries; i++) {
+        const func = async () => {
+          const chunk = stackTraceIDs.slice(chunkSize * i, chunkSize * (i + 1));
+          return client.mget({
             index: 'profiling-stacktraces',
-            size: stackTraceEvents.size,
-            sort: '_doc',
-            query: {
-              ids: {
-                values: [...stackTraceEvents.keys()],
-              },
-            },
-            _source: false,
-            docvalue_fields: ['FrameID', 'Type'],
-          },
-          {
-            querystring: {
-              filter_path: 'hits.hits._id,hits.hits.fields.FrameID,hits.hits.fields.Type',
-            },
-          }
-        );
-      } else {
-        return await client.mget({
-          index: 'profiling-stacktraces',
-          ids: [...stackTraceEvents.keys()],
-          _source_includes: ['FrameID', 'Type'],
+            ids: [...chunk],
+            _source_includes: ['FrameID', 'Type'],
+          });
+        };
+
+        // Build and send the queries asynchronously.
+        promises[i] = func();
+      }
+
+      logger.info('B');
+
+      /*      for (let i = 0; i < nQueries; i++) {
+        await Promise.any(promises).then((res) => {
+          results[i] = res;
+          logger.info('Got result ' + res.body.docs.length);
         });
+      }*/
+
+      /*      await Promise.all(promises).then((res) => {
+        results.push(res);
+        logger.info('Got result');
+        logger.info(`Results: ` + res);
+      });
+*/
+      for (let i = 0; i < nQueries; i++) {
+        results[i] = await promises[i];
       }
     }
   );
 
-  // Sometimes we don't find the trace.
-  // This is due to ES delays writing (data is not immediately seen after write).
-  // Also, ES doesn't know about transactions.
+  logger.info('results len ' + results.length);
 
   // Create a lookup map StackTraceID -> StackTrace.
   const stackTraces = new Map<StackTraceID, StackTrace>();
-  if (testing) {
-    // console.log(JSON.stringify(resStackTraces, null, 2));
-
-    for (const trace of resStackTraces.body.hits.hits) {
-      const frameIDs = trace.fields.FrameID as string[];
-      const fileIDs = extractFileIDArrayFromFrameIDArray(frameIDs);
-      stackTraces.set(trace._id, {
-        FileID: fileIDs,
-        FrameID: frameIDs,
-        Type: trace.fields.Type,
-      });
-    }
-  } else {
-    for (const trace of resStackTraces.body.docs) {
-      if (trace.found) {
-        const frameIDs = trace._source.FrameID as string[];
+  for (let i = 0; i < nQueries; i++) {
+    if (testing) {
+      for (const trace of results[i].body.hits.hits) {
+        const frameIDs = trace.fields.FrameID as string[];
         const fileIDs = extractFileIDArrayFromFrameIDArray(frameIDs);
         stackTraces.set(trace._id, {
           FileID: fileIDs,
           FrameID: frameIDs,
-          Type: trace._source.Type,
+          Type: trace.fields.Type,
         });
+      }
+    } else {
+      for (const trace of results[i].body.docs) {
+        // Sometimes we don't find the trace.
+        // This is due to ES delays writing (data is not immediately seen after write).
+        // Also, ES doesn't know about transactions.
+        if (trace.found) {
+          const frameIDs = trace._source.FrameID as string[];
+          const fileIDs = extractFileIDArrayFromFrameIDArray(frameIDs);
+          stackTraces.set(trace._id, {
+            FileID: fileIDs,
+            FrameID: frameIDs,
+            Type: trace._source.Type,
+          });
+        }
       }
     }
   }
+
   if (stackTraces.size < stackTraceEvents.size) {
     logger.info(
       'failed to find ' +

--- a/src/plugins/profiling/server/routes/search_flamechart.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.ts
@@ -304,8 +304,6 @@ async function queryFlameGraph(
       const chunkSize = Math.floor(stackTraceEvents.size / nQueries);
       const stackTraceIDs = [...stackTraceEvents.keys()];
 
-      logger.info('A');
-
       for (let i = 0; i < nQueries; i++) {
         const func = async () => {
           const chunk = stackTraceIDs.slice(chunkSize * i, chunkSize * (i + 1));
@@ -314,8 +312,6 @@ async function queryFlameGraph(
             ids: [...chunk],
             _source_includes: ['FrameID', 'Type'],
           });
-
-          logger.info('res ' + i);
 
           if (testing) {
             for (const trace of res.body.hits.hits) {
@@ -349,45 +345,11 @@ async function queryFlameGraph(
         promises[i] = func();
       }
 
-      logger.info('B');
       await Promise.all(promises).catch((err) => {
         logger.error('Failed to get stacktraces from _mget: ' + err.message);
       });
     }
   );
-  /*
-  logger.info('results len ' + results.length);
-
-  // Create a lookup map StackTraceID -> StackTrace.
-  for (let i = 0; i < nQueries; i++) {
-    if (testing) {
-      for (const trace of results[i].body.hits.hits) {
-        const frameIDs = trace.fields.FrameID as string[];
-        const fileIDs = extractFileIDArrayFromFrameIDArray(frameIDs);
-        stackTraces.set(trace._id, {
-          FileID: fileIDs,
-          FrameID: frameIDs,
-          Type: trace.fields.Type,
-        });
-      }
-    } else {
-      for (const trace of results[i].body.docs) {
-        // Sometimes we don't find the trace.
-        // This is due to ES delays writing (data is not immediately seen after write).
-        // Also, ES doesn't know about transactions.
-        if (trace.found) {
-          const frameIDs = trace._source.FrameID as string[];
-          const fileIDs = extractFileIDArrayFromFrameIDArray(frameIDs);
-          stackTraces.set(trace._id, {
-            FileID: fileIDs,
-            FrameID: frameIDs,
-            Type: trace._source.Type,
-          });
-        }
-      }
-    }
-  }
-*/
 
   if (stackTraces.size < stackTraceEvents.size) {
     logger.info(
@@ -397,7 +359,8 @@ async function queryFlameGraph(
     );
   }
 
-  /*  logger.info(
+  /*
+    logger.info(
     '* unique stacktraces without leaf frame: ' +
       getNumberOfUniqueStacktracesWithoutLeafNode(stackTraces, 1)
   );

--- a/src/plugins/profiling/server/routes/search_flamechart.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.ts
@@ -360,7 +360,7 @@ async function queryFlameGraph(
     );
   }
 
-  logger.info(
+  /*  logger.info(
     '* unique stacktraces without leaf frame: ' +
       getNumberOfUniqueStacktracesWithoutLeafNode(stackTraces, 1)
   );
@@ -369,6 +369,7 @@ async function queryFlameGraph(
     '* unique stacktraces without 2 leaf frames: ' +
       getNumberOfUniqueStacktracesWithoutLeafNode(stackTraces, 2)
   );
+*/
 
   // Create the set of unique FrameIDs.
   const stackFrameDocIDs = new Set<string>();

--- a/src/plugins/profiling/server/routes/search_topn.test.ts
+++ b/src/plugins/profiling/server/routes/search_topn.test.ts
@@ -90,6 +90,7 @@ describe('TopN data from Elasticsearch', () => {
         '123',
         '456',
         '789',
+        200,
         'field',
         kibanaResponseFactory
       );
@@ -112,6 +113,7 @@ describe('TopN data from Elasticsearch', () => {
         '123',
         '456',
         '789',
+        200,
         'StackTraceID',
         kibanaResponseFactory
       );


### PR DESCRIPTION
I need your JS/TS expertise :-)
I would like to process the results of the first finished query while the other queries still run in the background. How do I achieve that ?