### PR TITLE
Instrument Top N queries to measure latency

### DIFF
--- a/src/plugins/profiling/server/routes/index.ts
+++ b/src/plugins/profiling/server/routes/index.ts
@@ -40,9 +40,9 @@ export function registerRoutes(router: IRouter<DataRequestHandlerContext>, logge
 
   registerFlameChartElasticSearchRoute(router, logger!);
   registerFlameChartPixiSearchRoute(router, logger!);
-  registerTraceEventsTopNContainersSearchRoute(router);
-  registerTraceEventsTopNDeploymentsSearchRoute(router);
-  registerTraceEventsTopNHostsSearchRoute(router);
-  registerTraceEventsTopNStackTracesSearchRoute(router);
-  registerTraceEventsTopNThreadsSearchRoute(router);
+  registerTraceEventsTopNContainersSearchRoute(router, logger!);
+  registerTraceEventsTopNDeploymentsSearchRoute(router, logger!);
+  registerTraceEventsTopNHostsSearchRoute(router, logger!);
+  registerTraceEventsTopNStackTracesSearchRoute(router, logger!);
+  registerTraceEventsTopNThreadsSearchRoute(router, logger!);
 }

--- a/src/plugins/profiling/server/routes/logger.ts
+++ b/src/plugins/profiling/server/routes/logger.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import type { Logger } from 'kibana/server';
+
+export async function logExecutionLatency<T>(
+  logger: Logger,
+  activity: string,
+  func: () => Promise<T>
+): Promise<T> {
+  const start = new Date().getTime();
+  return await func().then((res) => {
+    logger.info(activity + ' took ' + (new Date().getTime() - start) + 'ms');
+    return res;
+  });
+}

--- a/src/plugins/profiling/server/routes/search_flamechart.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.ts
@@ -19,23 +19,12 @@ import {
   StackTrace,
   StackTraceID,
 } from '../../common/profiling';
+import { logExecutionLatency } from './logger';
 import { newProjectTimeQuery, ProjectTimeQuery } from './mappings';
 
 export interface DownsampledEventsIndex {
   name: string;
   sampleRate: number;
-}
-
-async function logExecutionLatency<T>(
-  logger: Logger,
-  activity: string,
-  func: () => Promise<T>
-): Promise<T> {
-  const start = new Date().getTime();
-  return await func().then((res) => {
-    logger.info(activity + ' took ' + (new Date().getTime() - start) + 'ms');
-    return res;
-  });
 }
 
 // convertFrameIDToFileID extracts the FileID from the FrameID and returns as base64url string.

--- a/src/plugins/profiling/server/routes/search_topn.ts
+++ b/src/plugins/profiling/server/routes/search_topn.ts
@@ -14,6 +14,7 @@ import {
 } from '@elastic/elasticsearch/lib/api/types';
 import type { DataRequestHandlerContext } from '../../../data/server';
 import { getRemoteRoutePaths } from '../../common';
+import { logExecutionLatency } from './logger';
 import { autoHistogramSumCountOnGroupByField, newProjectTimeQuery } from './mappings';
 
 export async function topNElasticSearchQuery(

--- a/src/plugins/profiling/server/routes/search_topn.ts
+++ b/src/plugins/profiling/server/routes/search_topn.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 import { schema } from '@kbn/config-schema';
-import type { IRouter, KibanaResponseFactory } from 'kibana/server';
+import type { IRouter, KibanaResponseFactory, Logger } from 'kibana/server';
 import {
   AggregationsHistogramAggregate,
   AggregationsHistogramBucket,
@@ -18,6 +18,7 @@ import { autoHistogramSumCountOnGroupByField, newProjectTimeQuery } from './mapp
 
 export async function topNElasticSearchQuery(
   context: DataRequestHandlerContext,
+  logger: Logger,
   index: string,
   projectID: string,
   timeFrom: string,
@@ -69,6 +70,7 @@ export async function topNElasticSearchQuery(
 
 export function queryTopNCommon(
   router: IRouter<DataRequestHandlerContext>,
+  logger: Logger,
   pathName: string,
   searchField: string
 ) {
@@ -91,6 +93,7 @@ export function queryTopNCommon(
       try {
         return await topNElasticSearchQuery(
           context,
+          logger,
           index,
           projectID,
           timeFrom,
@@ -112,36 +115,41 @@ export function queryTopNCommon(
 }
 
 export function registerTraceEventsTopNContainersSearchRoute(
-  router: IRouter<DataRequestHandlerContext>
+  router: IRouter<DataRequestHandlerContext>,
+  logger: Logger
 ) {
   const paths = getRemoteRoutePaths();
-  return queryTopNCommon(router, paths.TopNContainers, 'ContainerName');
+  return queryTopNCommon(router, logger, paths.TopNContainers, 'ContainerName');
 }
 
 export function registerTraceEventsTopNDeploymentsSearchRoute(
-  router: IRouter<DataRequestHandlerContext>
+  router: IRouter<DataRequestHandlerContext>,
+  logger: Logger
 ) {
   const paths = getRemoteRoutePaths();
-  return queryTopNCommon(router, paths.TopNDeployments, 'PodName');
+  return queryTopNCommon(router, logger, paths.TopNDeployments, 'PodName');
 }
 
 export function registerTraceEventsTopNHostsSearchRoute(
-  router: IRouter<DataRequestHandlerContext>
+  router: IRouter<DataRequestHandlerContext>,
+  logger: Logger
 ) {
   const paths = getRemoteRoutePaths();
-  return queryTopNCommon(router, paths.TopNHosts, 'HostID');
+  return queryTopNCommon(router, logger, paths.TopNHosts, 'HostID');
 }
 
 export function registerTraceEventsTopNStackTracesSearchRoute(
-  router: IRouter<DataRequestHandlerContext>
+  router: IRouter<DataRequestHandlerContext>,
+  logger: Logger
 ) {
   const paths = getRemoteRoutePaths();
-  return queryTopNCommon(router, paths.TopNTraces, 'StackTraceID');
+  return queryTopNCommon(router, logger, paths.TopNTraces, 'StackTraceID');
 }
 
 export function registerTraceEventsTopNThreadsSearchRoute(
-  router: IRouter<DataRequestHandlerContext>
+  router: IRouter<DataRequestHandlerContext>,
+  logger: Logger
 ) {
   const paths = getRemoteRoutePaths();
-  return queryTopNCommon(router, paths.TopNThreads, 'ThreadName');
+  return queryTopNCommon(router, logger, paths.TopNThreads, 'ThreadName');
 }


### PR DESCRIPTION
This PR adds logging to the Top N queries so that we can measure latency before trying to downsample results.