### PR TITLE
Flamegraph: small tweaks

### DIFF
--- a/src/plugins/profiling/server/routes/search_flamechart.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.ts
@@ -173,6 +173,7 @@ async function queryFlameGraph(
   const nQueries = 8;
   const stackTraces = new Map<StackTraceID, StackTrace>();
   const stackFrameDocIDs = new Set<string>(); // Set of unique FrameIDs
+  const executableDocIDs = new Set<string>(); // Set of unique executable FileIDs.
 
   await logExecutionLatency(
     logger,
@@ -203,6 +204,9 @@ async function queryFlameGraph(
               for (const frameID of frameIDs) {
                 stackFrameDocIDs.add(frameID);
               }
+              for (const fileID of fileIDs) {
+                executableDocIDs.add(fileID);
+              }
             }
           } else {
             for (const trace of res.body.docs) {
@@ -219,6 +223,9 @@ async function queryFlameGraph(
                 });
                 for (const frameID of frameIDs) {
                   stackFrameDocIDs.add(frameID);
+                }
+                for (const fileID of fileIDs) {
+                  executableDocIDs.add(fileID);
                 }
               }
             }
@@ -284,14 +291,6 @@ async function queryFlameGraph(
     }
   }
   logger.info('found ' + framesFound + ' / ' + stackFrameDocIDs.size + ' frames');
-
-  // Create the set of unique executable FileIDs.
-  const executableDocIDs = new Set<string>();
-  for (const trace of stackTraces.values()) {
-    for (const fileID of trace.FileID) {
-      executableDocIDs.add(fileID);
-    }
-  }
 
   const resExecutables = await logExecutionLatency(
     logger,

--- a/src/plugins/profiling/server/routes/search_flamechart.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.ts
@@ -172,6 +172,7 @@ async function queryFlameGraph(
   // profiling-stacktraces is configured with 16 shards
   const nQueries = 8;
   const stackTraces = new Map<StackTraceID, StackTrace>();
+  const stackFrameDocIDs = new Set<string>(); // Set of unique FrameIDs
 
   await logExecutionLatency(
     logger,
@@ -199,6 +200,9 @@ async function queryFlameGraph(
                 FrameID: frameIDs,
                 Type: trace.fields.Type,
               });
+              for (const frameID of frameIDs) {
+                stackFrameDocIDs.add(frameID);
+              }
             }
           } else {
             for (const trace of res.body.docs) {
@@ -213,6 +217,9 @@ async function queryFlameGraph(
                   FrameID: frameIDs,
                   Type: trace._source.Type,
                 });
+                for (const frameID of frameIDs) {
+                  stackFrameDocIDs.add(frameID);
+                }
               }
             }
           }
@@ -247,14 +254,6 @@ async function queryFlameGraph(
       getNumberOfUniqueStacktracesWithoutLeafNode(stackTraces, 2)
   );
 */
-
-  // Create the set of unique FrameIDs.
-  const stackFrameDocIDs = new Set<string>();
-  for (const trace of stackTraces.values()) {
-    for (const frameID of trace.FrameID) {
-      stackFrameDocIDs.add(frameID);
-    }
-  }
 
   const resStackFrames = await logExecutionLatency(
     logger,


### PR DESCRIPTION
This includes splitting the mget requests and the data processing. It should improve comparisons as the data processing latency is very flaky - on the same data it takes locally between 400 and 1000 milliseconds (pretty random).
