### PR TITLE
Fix failing TopN tests

### DIFF
--- a/src/plugins/profiling/server/routes/downsampling.ts
+++ b/src/plugins/profiling/server/routes/downsampling.ts
@@ -27,7 +27,7 @@ function getFullDownsampledIndex(index: string, i: number): string {
 //
 // More details on how the down-sampling works can be found at the write path
 //   https://github.com/elastic/prodfiler/blob/bdcc2711c6cd7e89d63b58a17329fb9fdbabe008/pf-elastic-collector/elastic.go
-function getSampledTraceEventsIndex(
+export function getSampledTraceEventsIndex(
   index: string,
   targetSampleSize: number,
   sampleCountFromInitialExp: number,
@@ -52,7 +52,10 @@ function getSampledTraceEventsIndex(
     }
     // If we come here, it means that the most sparse index still holds too many items.
     // The only problem is the query time, the result set is good.
-    return { name: getFullDownsampledIndex(index, maxExp), sampleRate: 1 / samplingFactor ** maxExp };
+    return {
+      name: getFullDownsampledIndex(index, maxExp),
+      sampleRate: 1 / samplingFactor ** maxExp,
+    };
   } else if (sampleCountFromInitialExp < targetSampleSize) {
     // Search in less down-sampled indexes.
     for (let i = initialExp - 1; i >= 1; i--) {

--- a/src/plugins/profiling/server/routes/search_flamechart.test.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.test.ts
@@ -6,12 +6,8 @@
  * Side Public License, v 1.
  */
 
-import {
-  getSampledTraceEventsIndex,
-  extractFileIDFromFrameID,
-  DownsampledEventsIndex,
-  parallelMget,
-} from './search_flamechart';
+import { DownsampledEventsIndex, getSampledTraceEventsIndex } from './downsampling';
+import { extractFileIDFromFrameID, parallelMget } from './search_flamechart';
 import { ElasticsearchClient } from 'kibana/server';
 
 describe('Using down-sampled indexes', () => {

--- a/src/plugins/profiling/server/routes/search_topn.test.ts
+++ b/src/plugins/profiling/server/routes/search_topn.test.ts
@@ -72,7 +72,7 @@ describe('TopN data from Elasticsearch', () => {
         'StackTraceID',
         kibanaResponseFactory
       );
-      expect(client.search).toHaveBeenCalledTimes(1);
+      expect(client.search).toHaveBeenCalledTimes(2);
       expect(client.mget).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/plugins/profiling/server/routes/search_topn.test.ts
+++ b/src/plugins/profiling/server/routes/search_topn.test.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { loggerMock } from '@kbn/logging/mocks';
 import { topNElasticSearchQuery } from './search_topn';
 import { ElasticsearchClient, kibanaResponseFactory } from '../../../../core/server';
 import { coreMock } from '../../../../core/server/mocks';
@@ -27,6 +28,7 @@ jest.mock('./mappings', () => ({
 describe('TopN data from Elasticsearch', () => {
   const context = coreMock.createRequestHandlerContext();
   const client = context.elasticsearch.client.asCurrentUser as ElasticsearchClient;
+  const logger = loggerMock.create();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -36,6 +38,7 @@ describe('TopN data from Elasticsearch', () => {
     it('filters by projectID and aggregates timerange on histogram', async () => {
       await topNElasticSearchQuery(
         client,
+        logger,
         index,
         '123',
         '456',
@@ -55,10 +58,12 @@ describe('TopN data from Elasticsearch', () => {
       });
     });
   });
+
   describe('when fetching Stack Traces', () => {
     it('should search first then mget', async () => {
       await topNElasticSearchQuery(
         client,
+        logger,
         index,
         '123',
         '456',

--- a/src/plugins/profiling/server/routes/search_topn.ts
+++ b/src/plugins/profiling/server/routes/search_topn.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 import { schema } from '@kbn/config-schema';
-import type { IRouter, KibanaResponseFactory, Logger } from 'kibana/server';
+import type { ElasticsearchClient, IRouter, KibanaResponseFactory, Logger } from 'kibana/server';
 import {
   AggregationsHistogramAggregate,
   AggregationsHistogramBucket,
@@ -19,9 +19,8 @@ import { findDownsampledIndex } from './downsampling';
 import { logExecutionLatency } from './logger';
 import { autoHistogramSumCountOnGroupByField, newProjectTimeQuery } from './mappings';
 
-
 export async function topNElasticSearchQuery(
-  context: DataRequestHandlerContext,
+  client: ElasticsearchClient,
   logger: Logger,
   index: string,
   projectID: string,
@@ -31,7 +30,6 @@ export async function topNElasticSearchQuery(
   searchField: string,
   response: KibanaResponseFactory
 ) {
-  const esClient = context.core.elasticsearch.client.asCurrentUser;
   const filter = newProjectTimeQuery(projectID, timeFrom, timeTo);
   const targetSampleSize = 20000; // minimum number of samples to get statistically sound results
 
@@ -39,7 +37,7 @@ export async function topNElasticSearchQuery(
     logger,
     'query to find downsampled index',
     async () => {
-      return await findDownsampledIndex(logger, esClient, index, filter, targetSampleSize);
+      return await findDownsampledIndex(logger, client, index, filter, targetSampleSize);
     }
   );
 
@@ -47,7 +45,7 @@ export async function topNElasticSearchQuery(
     logger,
     'query to fetch events from ' + eventsIndex.name,
     async () => {
-      return await esClient.search({
+      return await client.search({
         index: eventsIndex.name,
         body: {
           query: filter,
@@ -62,14 +60,14 @@ export async function topNElasticSearchQuery(
   let totalCount = 0;
   const stackTraceEvents = new Set<StackTraceID>();
 
-  (
-    resEvents.body.aggregations?.histogram as AggregationsHistogramAggregate
-  ).buckets.forEach((timeInterval: AggregationsHistogramBucket) => {
-    totalCount += timeInterval.doc_count;
-    timeInterval.group_by.buckets.forEach((stackTraceItem: AggregationsStringTermsBucket) => {
-      stackTraceEvents.add(stackTraceItem.key);
-    });
-  });
+  (resEvents.body.aggregations?.histogram as AggregationsHistogramAggregate).buckets.forEach(
+    (timeInterval: AggregationsHistogramBucket) => {
+      totalCount += timeInterval.doc_count;
+      timeInterval.group_by.buckets.forEach((stackTraceItem: AggregationsStringTermsBucket) => {
+        stackTraceEvents.add(stackTraceItem.key);
+      });
+    }
+  );
 
   logger.info('events total count: ' + totalCount);
   logger.info('unique stacktraces: ' + stackTraceEvents.size);
@@ -86,7 +84,7 @@ export async function topNElasticSearchQuery(
     logger,
     'query for ' + stackTraceEvents.size + ' stacktraces',
     async () => {
-      return await esClient.mget({
+      return await client.mget({
         index: 'profiling-stacktraces',
         body: { ids: [...stackTraceEvents] },
       });
@@ -122,10 +120,11 @@ export function queryTopNCommon(
     },
     async (context, request, response) => {
       const { index, projectID, timeFrom, timeTo, n } = request.query;
+      const client = context.core.elasticsearch.client.asCurrentUser;
 
       try {
         return await topNElasticSearchQuery(
-          context,
+          client,
           logger,
           index,
           projectID,

--- a/src/plugins/profiling/server/routes/search_topn.ts
+++ b/src/plugins/profiling/server/routes/search_topn.ts
@@ -60,7 +60,7 @@ export async function topNElasticSearchQuery(
   let totalCount = 0;
   const stackTraceEvents = new Set<StackTraceID>();
 
-  (resEvents.body.aggregations?.histogram as AggregationsHistogramAggregate).buckets.forEach(
+  (resEvents.body.aggregations?.histogram as AggregationsHistogramAggregate)?.buckets?.forEach(
     (timeInterval: AggregationsHistogramBucket) => {
       totalCount += timeInterval.doc_count;
       timeInterval.group_by.buckets.forEach((stackTraceItem: AggregationsStringTermsBucket) => {


### PR DESCRIPTION
This PR fixes the failing TopN tests, but also refactored the tests to use mock objects for the logger and Elasticsearch client.