### PR TITLE
Tim/search vs mget

### DIFF
--- a/src/plugins/profiling/server/routes/search_flamechart.ts
+++ b/src/plugins/profiling/server/routes/search_flamechart.ts
@@ -189,7 +189,12 @@ async function queryFlameGraph(
   const executableDocIDs = new Set<string>(); // Set of unique executable FileIDs.
   const stackTraceIDs = [...stackTraceEvents.keys()];
   const chunkSize = Math.floor(stackTraceEvents.size / nQueries);
-  const chunks = chunk(stackTraceIDs, chunkSize);
+  let chunks = chunk(stackTraceIDs, chunkSize);
+
+  if (chunks.length !== nQueries) {
+    // The last array element contains the remainder, just drop it as irrelevant.
+    chunks = chunks.slice(0, nQueries);
+  }
 
   const stackResponses = await logExecutionLatency(
     logger,


### PR DESCRIPTION
Use 'FlameGraph (Elastic2)' with search instead of mget.

Locally, this takes ~2x longer than mget (480ms vs 240ms).
But let's see how it performs on non-cached data in the MVP cluster.