### PR TITLE
Flamegraph: reduce events processing time

### DIFF
--- a/src/plugins/profiling/server/routes/flamechart.ts
+++ b/src/plugins/profiling/server/routes/flamechart.ts
@@ -200,7 +200,7 @@ async function queryFlameGraph(
   }
 
   // profiling-stacktraces is configured with 16 shards
-  const nQueries = 8;
+  const nQueries = 1;
   const stackTraces = new Map<StackTraceID, StackTrace>();
   const stackFrameDocIDs = new Set<string>(); // Set of unique FrameIDs
   const executableDocIDs = new Set<string>(); // Set of unique executable FileIDs.

--- a/src/plugins/profiling/server/routes/flamechart.ts
+++ b/src/plugins/profiling/server/routes/flamechart.ts
@@ -244,6 +244,7 @@ async function queryFlameGraph(
             return client.mget({
               index: 'profiling-stacktraces',
               ids,
+              realtime: false,
               _source_includes: ['FrameID', 'Type'],
             });
           }
@@ -336,6 +337,7 @@ async function queryFlameGraph(
       return await client.mget({
         index: 'profiling-stackframes',
         ids: [...stackFrameDocIDs],
+        realtime: false,
       });
     }
   );


### PR DESCRIPTION
One commit measures the events data processing and reduces the amount of JSON data by ~15%.

The other one improves the time for stacktraces processing by using two levels of LRUs.

My local measurements:
Before: 500-800ms
After: 100-300ms (100ms for hot caches, 300ms for cold caches)
