### PR TITLE
Use term aggregations /w execution_hint:map for events - 100x speedup on the MVP cluster

### DIFF
--- a/src/plugins/profiling/common/flamegraph.ts
+++ b/src/plugins/profiling/common/flamegraph.ts
@@ -77,7 +77,6 @@ export class FlameGraph {
 
   private getExeFileName(exe: any, type: number) {
     if (exe?.FileName === undefined) {
-      this.logger.warn('missing executable FileName');
       return '';
     }
     if (exe.FileName !== '') {

--- a/src/plugins/profiling/server/routes/compat.ts
+++ b/src/plugins/profiling/server/routes/compat.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+// Code that works around incompatibilities between different
+// versions of Kibana / ES.
+// Currently, we work with 8.1 and 8.3 and thus this code only needs
+// to address the incompatibilities between those two versions.
+
+import type { TransportResult } from '@elastic/transport/lib/types';
+import type {
+  SearchResponse,
+  SearchHitsMetadata,
+  SearchHit,
+  MgetResponse,
+  MgetResponseItem,
+  AggregationsAggregate,
+} from '@elastic/elasticsearch/lib/api/types';
+import type { ElasticsearchClient } from 'kibana/server';
+import type { DataRequestHandlerContext } from '../../../data/server';
+
+// Search results in 8.1 have 'body' but not in 8.3.
+export function getHits(
+  res: TransportResult<SearchResponse<unknown, Record<string, AggregationsAggregate>>, unknown>
+): SearchHitsMetadata<unknown> {
+  return 'body' in res ? res.body.hits : res.hits;
+}
+
+export function getAggs(
+  res: TransportResult<SearchResponse<unknown, Record<string, AggregationsAggregate>>, unknown>
+): Record<string, AggregationsAggregate> | undefined {
+  return 'body' in res ? res.body.aggregations : res.aggregations;
+}
+
+export function getHitsItems(
+  res: TransportResult<SearchResponse<unknown, Record<string, AggregationsAggregate>>, unknown>
+): Array<SearchHit<unknown>> {
+  return getHits(res)?.hits ?? [];
+}
+
+// Mget results in 8.1 have 'body' but not in 8.3.
+export function getDocs(
+  res: TransportResult<MgetResponse<any>, unknown>
+): Array<MgetResponseItem<any>> {
+  return ('body' in res ? res.body.docs : res.docs) ?? [];
+}
+
+// In 8.3, context.core is a Promise.
+export async function getClient(context: DataRequestHandlerContext): Promise<ElasticsearchClient> {
+  return typeof context.core.then === 'function'
+    ? (await context.core).elasticsearch.client.asCurrentUser
+    : context.core.elasticsearch.client.asCurrentUser;
+}

--- a/src/plugins/profiling/server/routes/downsampling.ts
+++ b/src/plugins/profiling/server/routes/downsampling.ts
@@ -10,6 +10,7 @@ import seedrandom from 'seedrandom';
 import type { ElasticsearchClient, Logger } from 'kibana/server';
 import { ProjectTimeQuery } from './mappings';
 import { StackTraceID } from '../../common/profiling';
+import { getHits } from './compat';
 
 export interface DownsampledEventsIndex {
   name: string;
@@ -97,7 +98,7 @@ export async function findDownsampledIndex(
         track_total_hits: true,
       },
     });
-    sampleCountFromInitialExp = resp.body.hits.total?.value as number;
+    sampleCountFromInitialExp = getHits(resp).total?.value as number;
   } catch (e) {
     logger.info(e.message);
   }

--- a/src/plugins/profiling/server/routes/flamechart.ts
+++ b/src/plugins/profiling/server/routes/flamechart.ts
@@ -6,8 +6,8 @@
  * Side Public License, v 1.
  */
 import { schema } from '@kbn/config-schema';
-import type { ElasticsearchClient, IRouter, Logger } from '@kbn/core/server';
-import type { DataRequestHandlerContext } from '@kbn/data-plugin/server';
+import type { ElasticsearchClient, IRouter, Logger } from 'kibana/server';
+import type { DataRequestHandlerContext } from '../../../data/server';
 import { getRoutePaths } from '../../common';
 import { FlameGraph } from '../../common/flamegraph';
 import { StackTraceID } from '../../common/profiling';
@@ -15,6 +15,7 @@ import { logExecutionLatency } from './logger';
 import { newProjectTimeQuery, ProjectTimeQuery } from './mappings';
 import { downsampleEventsRandomly, findDownsampledIndex } from './downsampling';
 import { mgetExecutables, mgetStackFrames, mgetStackTraces, searchStackTraces } from './stacktrace';
+import { getHitsItems, getAggs, getClient } from './compat';
 
 export function parallelMget(
   nQueries: number,
@@ -70,29 +71,53 @@ async function queryFlameGraph(
         {
           index: eventsIndex.name,
           track_total_hits: false,
-          size: 150000, // should be max 100k, but might be more. Better be on the safe side.
           query: filter,
+          aggs: {
+            group_by: {
+              terms: {
+                // 'size' should be max 100k, but might be slightly more. Better be on the safe side.
+                size: 150000,
+                field: 'StackTraceID',
+                // 'execution_hint: map' skips the slow building of ordinals that we don't need.
+                // Especially with high cardinality fields, this makes aggregations really slow.
+                // E.g. it reduces the latency from 70s to 0.7s on our 8.1. MVP cluster (as of 28.04.2022).
+                execution_hint: 'map',
+              },
+              aggs: {
+                count: {
+                  sum: {
+                    field: 'Count',
+                  },
+                },
+              },
+            },
+            total_count: {
+              sum: {
+                field: 'Count',
+              },
+            },
+          },
         },
         {
           // Adrien and Dario found out this is a work-around for some bug in 8.1.
           // It reduces the query time by avoiding unneeded searches.
           querystring: {
             pre_filter_shard_size: 1,
-            filter_path: 'hits.hits._source.StackTraceID,hits.hits._source.Count,_shards.failures',
+            filter_path:
+              'aggregations.group_by.buckets.key,aggregations.group_by.buckets.count,aggregations.total_count,_shards.failures',
           },
         }
       );
     }
   );
 
-  let totalCount: number = 0;
+  let totalCount: number = getAggs(resEvents)?.total_count.value;
   const stackTraceEvents = new Map<StackTraceID, number>();
 
   await logExecutionLatency(logger, 'processing events data', async () => {
-    ('body' in resEvents ? resEvents.body.hits.hits : resEvents.hits.hits).forEach((item: any) => {
-      const traceid: StackTraceID = item._source.StackTraceID;
-      stackTraceEvents.set(traceid, item._source.Count + stackTraceEvents.get(traceid) ?? 0);
-      totalCount += item._source.Count;
+    getAggs(resEvents)?.group_by.buckets.forEach((item: any) => {
+      const traceid: StackTraceID = item.key;
+      stackTraceEvents.set(traceid, item.count.value);
     });
   });
   logger.info('events total count: ' + totalCount);
@@ -153,10 +178,7 @@ export function registerFlameChartElasticSearchRoute(
       const targetSampleSize = 20000; // minimum number of samples to get statistically sound results
 
       try {
-        const esClient =
-          typeof context.core.then === 'function'
-            ? (await context.core).elasticsearch.client.asCurrentUser
-            : context.core.elasticsearch.client.asCurrentUser;
+        const esClient = await getClient(context);
         const filter = newProjectTimeQuery(projectID!, timeFrom!, timeTo!);
 
         const flamegraph = await queryFlameGraph(
@@ -207,10 +229,7 @@ export function registerFlameChartPixiSearchRoute(
       const targetSampleSize = 20000; // minimum number of samples to get statistically sound results
 
       try {
-        const esClient =
-          typeof context.core.then === 'function'
-            ? (await context.core).elasticsearch.client.asCurrentUser
-            : context.core.elasticsearch.client.asCurrentUser;
+        const esClient = await getClient(context);
         const filter = newProjectTimeQuery(projectID!, timeFrom!, timeTo!);
 
         const flamegraph = await queryFlameGraph(

--- a/src/plugins/profiling/server/routes/topn.ts
+++ b/src/plugins/profiling/server/routes/topn.ts
@@ -20,6 +20,7 @@ import { findDownsampledIndex } from './downsampling';
 import { logExecutionLatency } from './logger';
 import { autoHistogramSumCountOnGroupByField, newProjectTimeQuery } from './mappings';
 import { mgetExecutables, mgetStackFrames, mgetStackTraces } from './stacktrace';
+import { getClient, getAggs } from './compat';
 
 export async function topNElasticSearchQuery(
   client: ElasticsearchClient,
@@ -67,7 +68,7 @@ export async function topNElasticSearchQuery(
     }
   );
 
-  const histogram = resEvents.body.aggregations?.histogram as AggregationsHistogramAggregate;
+  const histogram = getAggs(resEvents)?.histogram as AggregationsHistogramAggregate;
   const topN = createTopNBucketsByDate(histogram);
 
   if (searchField !== 'StackTraceID') {
@@ -136,10 +137,7 @@ export function queryTopNCommon(
     },
     async (context, request, response) => {
       const { index, projectID, timeFrom, timeTo, n } = request.query;
-      const client =
-        typeof context.core.then === 'function'
-          ? (await context.core).elasticsearch.client.asCurrentUser
-          : context.core.elasticsearch.client.asCurrentUser;
+      const client = await getClient(context);
 
       try {
         return await topNElasticSearchQuery(

--- a/src/plugins/profiling/server/routes/topn.ts
+++ b/src/plugins/profiling/server/routes/topn.ts
@@ -136,7 +136,10 @@ export function queryTopNCommon(
     },
     async (context, request, response) => {
       const { index, projectID, timeFrom, timeTo, n } = request.query;
-      const client = context.core.elasticsearch.client.asCurrentUser;
+      const client =
+        typeof context.core.then === 'function'
+          ? (await context.core).elasticsearch.client.asCurrentUser
+          : context.core.elasticsearch.client.asCurrentUser;
 
       try {
         return await topNElasticSearchQuery(


### PR DESCRIPTION
This is much faster on the MVP cluster.
I also had to apply some fixes in order to get the code running.
See https://elastic.slack.com/archives/C035P7UMXR7/p1650984764314609