### PR TITLE
Configure date and request parameters for all charts using UI

### DIFF
--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -39,6 +39,7 @@ type Props = Services;
 function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) {
   const [index, setIndex] = useState('profiling-events-all');
   const [projectID, setProjectID] = useState(5);
+  const [n, setN] = useState(100);
 
   const [topn, setTopN] = useState({
     samples: [],
@@ -50,6 +51,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
 
   const updateIndex = (idx: string) => setIndex(idx);
   const updateProjectID = (n: number) => setProjectID(n);
+  const updateN = (n: number) => setN(n);
 
   const tabs = [
     {
@@ -62,7 +64,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
             <StackTraceNavigation
               index={index}
               projectID={projectID}
-              n={100}
+              n={n}
               fetchTopN={fetchTopN}
               setTopN={setTopN}
             />
@@ -82,7 +84,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
             <FlameGraphNavigation
               index={index}
               projectID={projectID}
-              n={100}
+              n={n}
               getter={fetchElasticFlamechart}
               setter={setElasticFlamegraph}
             />
@@ -101,7 +103,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
             <FlameGraphNavigation
               index={index}
               projectID={projectID}
-              n={100}
+              n={n}
               getter={fetchPixiFlamechart}
               setter={setPixiFlamegraph}
             />
@@ -124,6 +126,8 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
               updateIndex={updateIndex}
               defaultProjectID={projectID}
               updateProjectID={updateProjectID}
+              defaultN={n}
+              updateN={updateN}
             />,
           ]}
         />

--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -62,6 +62,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
             <StackTraceNavigation
               index={index}
               projectID={projectID}
+              n={100}
               fetchTopN={fetchTopN}
               setTopN={setTopN}
             />
@@ -81,6 +82,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
             <FlameGraphNavigation
               index={index}
               projectID={projectID}
+              n={100}
               getter={fetchElasticFlamechart}
               setter={setElasticFlamegraph}
             />
@@ -99,6 +101,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
             <FlameGraphNavigation
               index={index}
               projectID={projectID}
+              n={100}
               getter={fetchPixiFlamechart}
               setter={setPixiFlamegraph}
             />

--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -42,7 +42,7 @@ function App({
   fetchElasticFlamechart2,
   fetchPixiFlamechart,
 }: Props) {
-  const [projectID, setProjectID] = useState(1);
+  const [projectID, setProjectID] = useState(5);
 
   const [topn, setTopN] = useState({
     samples: [],
@@ -63,7 +63,7 @@ function App({
         <>
           <EuiSpacer />
           <TopNContext.Provider value={topn}>
-            <StackTraceNavigation fetchTopN={fetchTopN} setTopN={setTopN} />
+            <StackTraceNavigation projectID={projectID} fetchTopN={fetchTopN} setTopN={setTopN} />
             <StackedBarChart id="topn" name="topn" height={400} x="x" y="y" category="g" />
             <ChartGrid maximum={10} />
           </TopNContext.Provider>
@@ -77,7 +77,11 @@ function App({
         <>
           <EuiSpacer />
           <FlameGraphContext.Provider value={elasticFlamegraph}>
-            <FlameGraphNavigation getter={fetchElasticFlamechart} setter={setElasticFlamegraph} />
+            <FlameGraphNavigation
+              projectID={projectID}
+              getter={fetchElasticFlamechart}
+              setter={setElasticFlamegraph}
+            />
             <FlameGraph id="flamechart" height={600} />
           </FlameGraphContext.Provider>
         </>
@@ -90,7 +94,11 @@ function App({
         <>
           <EuiSpacer />
           <FlameGraphContext.Provider value={elasticFlamegraph2}>
-            <FlameGraphNavigation getter={fetchElasticFlamechart2} setter={setElasticFlamegraph2} />
+            <FlameGraphNavigation
+              projectID={projectID}
+              getter={fetchElasticFlamechart2}
+              setter={setElasticFlamegraph2}
+            />
             <FlameGraph id="flamechart" height={600} />
           </FlameGraphContext.Provider>
         </>
@@ -103,7 +111,11 @@ function App({
         <>
           <EuiSpacer />
           <FlameGraphContext.Provider value={pixiFlamegraph}>
-            <FlameGraphNavigation getter={fetchPixiFlamechart} setter={setPixiFlamegraph} />
+            <FlameGraphNavigation
+              projectID={projectID}
+              getter={fetchPixiFlamechart}
+              setter={setPixiFlamegraph}
+            />
             <PixiFlamechart projectID={projectID.toString()} />
           </FlameGraphContext.Provider>
         </>

--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -36,12 +36,7 @@ import { Services } from './services';
 
 type Props = Services;
 
-function App({
-  fetchTopN,
-  fetchElasticFlamechart,
-  fetchElasticFlamechart2,
-  fetchPixiFlamechart,
-}: Props) {
+function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) {
   const [projectID, setProjectID] = useState(5);
 
   const [topn, setTopN] = useState({
@@ -50,7 +45,6 @@ function App({
   });
 
   const [elasticFlamegraph, setElasticFlamegraph] = useState({ leaves: [] });
-  const [elasticFlamegraph2, setElasticFlamegraph2] = useState({ leaves: [] });
   const [pixiFlamegraph, setPixiFlamegraph] = useState({});
 
   const updateProjectID = (n: number) => setProjectID(n);
@@ -63,7 +57,12 @@ function App({
         <>
           <EuiSpacer />
           <TopNContext.Provider value={topn}>
-            <StackTraceNavigation projectID={projectID} fetchTopN={fetchTopN} setTopN={setTopN} />
+            <StackTraceNavigation
+              index={'profiling-events-all'}
+              projectID={projectID}
+              fetchTopN={fetchTopN}
+              setTopN={setTopN}
+            />
             <StackedBarChart id="topn" name="topn" height={400} x="x" y="y" category="g" />
             <ChartGrid maximum={10} />
           </TopNContext.Provider>
@@ -78,26 +77,10 @@ function App({
           <EuiSpacer />
           <FlameGraphContext.Provider value={elasticFlamegraph}>
             <FlameGraphNavigation
+              index={'profiling-events-all'}
               projectID={projectID}
               getter={fetchElasticFlamechart}
               setter={setElasticFlamegraph}
-            />
-            <FlameGraph id="flamechart" height={600} />
-          </FlameGraphContext.Provider>
-        </>
-      ),
-    },
-    {
-      id: 'flamegraph-elastic2',
-      name: 'FlameGraph (Elastic2)',
-      content: (
-        <>
-          <EuiSpacer />
-          <FlameGraphContext.Provider value={elasticFlamegraph2}>
-            <FlameGraphNavigation
-              projectID={projectID}
-              getter={fetchElasticFlamechart2}
-              setter={setElasticFlamegraph2}
             />
             <FlameGraph id="flamechart" height={600} />
           </FlameGraphContext.Provider>
@@ -112,6 +95,7 @@ function App({
           <EuiSpacer />
           <FlameGraphContext.Provider value={pixiFlamegraph}>
             <FlameGraphNavigation
+              index={'profiling-events-all'}
               projectID={projectID}
               getter={fetchPixiFlamechart}
               setter={setPixiFlamegraph}

--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -37,6 +37,7 @@ import { Services } from './services';
 type Props = Services;
 
 function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) {
+  const [index, setIndex] = useState('profiling-events-all');
   const [projectID, setProjectID] = useState(5);
 
   const [topn, setTopN] = useState({
@@ -47,6 +48,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
   const [elasticFlamegraph, setElasticFlamegraph] = useState({ leaves: [] });
   const [pixiFlamegraph, setPixiFlamegraph] = useState({});
 
+  const updateIndex = (idx: string) => setIndex(idx);
   const updateProjectID = (n: number) => setProjectID(n);
 
   const tabs = [
@@ -58,7 +60,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
           <EuiSpacer />
           <TopNContext.Provider value={topn}>
             <StackTraceNavigation
-              index={'profiling-events-all'}
+              index={index}
               projectID={projectID}
               fetchTopN={fetchTopN}
               setTopN={setTopN}
@@ -77,7 +79,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
           <EuiSpacer />
           <FlameGraphContext.Provider value={elasticFlamegraph}>
             <FlameGraphNavigation
-              index={'profiling-events-all'}
+              index={index}
               projectID={projectID}
               getter={fetchElasticFlamechart}
               setter={setElasticFlamegraph}
@@ -95,7 +97,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
           <EuiSpacer />
           <FlameGraphContext.Provider value={pixiFlamegraph}>
             <FlameGraphNavigation
-              index={'profiling-events-all'}
+              index={index}
               projectID={projectID}
               getter={fetchPixiFlamechart}
               setter={setPixiFlamegraph}
@@ -114,7 +116,12 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
           paddingSize="s"
           pageTitle="Continuous Profiling"
           rightSideItems={[
-            <SettingsFlyout defaultProjectID={projectID} updateProjectID={updateProjectID} />,
+            <SettingsFlyout
+              defaultIndex={index}
+              updateIndex={updateIndex}
+              defaultProjectID={projectID}
+              updateProjectID={updateProjectID}
+            />,
           ]}
         />
         <EuiPageContent>

--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -15,9 +15,12 @@ import {
   EuiPageBody,
   EuiPageContent,
   EuiPageContentBody,
+  EuiPageHeader,
   EuiSpacer,
   EuiTabbedContent,
 } from '@elastic/eui';
+
+import { SettingsFlyout } from './components/settings-flyout';
 
 import { TopNContext } from './components/contexts/topn';
 import { StackTraceNavigation } from './components/stacktrace-nav';
@@ -39,6 +42,8 @@ function App({
   fetchElasticFlamechart2,
   fetchPixiFlamechart,
 }: Props) {
+  const [projectID, setProjectID] = useState(1);
+
   const [topn, setTopN] = useState({
     samples: [],
     series: new Map(),
@@ -47,6 +52,8 @@ function App({
   const [elasticFlamegraph, setElasticFlamegraph] = useState({ leaves: [] });
   const [elasticFlamegraph2, setElasticFlamegraph2] = useState({ leaves: [] });
   const [pixiFlamegraph, setPixiFlamegraph] = useState({});
+
+  const updateProjectID = (n: number) => setProjectID(n);
 
   const tabs = [
     {
@@ -97,7 +104,7 @@ function App({
           <EuiSpacer />
           <FlameGraphContext.Provider value={pixiFlamegraph}>
             <FlameGraphNavigation getter={fetchPixiFlamechart} setter={setPixiFlamegraph} />
-            <PixiFlamechart projectID={'5'} />
+            <PixiFlamechart projectID={projectID.toString()} />
           </FlameGraphContext.Provider>
         </>
       ),
@@ -106,9 +113,16 @@ function App({
 
   return (
     <EuiPage>
-      <EuiPageBody style={{ margin: '0 auto' }}>
+      <EuiPageBody paddingSize="none">
+        <EuiPageHeader
+          paddingSize="s"
+          pageTitle="Continuous Profiling"
+          rightSideItems={[
+            <SettingsFlyout defaultProjectID={projectID} updateProjectID={updateProjectID} />,
+          ]}
+        />
         <EuiPageContent>
-          <EuiPageContentBody style={{ margin: '0 auto' }}>
+          <EuiPageContentBody paddingSize="none">
             <EuiTabbedContent tabs={tabs} initialSelectedTab={tabs[0]} autoFocus="selected" />
           </EuiPageContentBody>
         </EuiPageContent>

--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -202,6 +202,7 @@ function App({ fetchTopN, fetchElasticFlamechart, fetchPixiFlamechart }: Props) 
               commonlyUsedRanges={commonlyUsedRanges}
             />,
             <SettingsFlyout
+              title={'Settings'}
               defaultIndex={index}
               updateIndex={updateIndex}
               defaultProjectID={projectID}

--- a/src/plugins/profiling/public/components/flamegraph-nav.tsx
+++ b/src/plugins/profiling/public/components/flamegraph-nav.tsx
@@ -6,80 +6,9 @@
  * Side Public License, v 1.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
-import dateMath from '@elastic/datemath';
-import { EuiSuperDatePicker } from '@elastic/eui';
-
-interface CommonlyUsedRange {
-  start: string;
-  end: string;
-  label: string;
-}
-
-const commonlyUsedRanges: CommonlyUsedRange[] = [
-  {
-    start: 'now-30m',
-    end: 'now',
-    label: 'Last 30 minutes',
-  },
-  {
-    start: 'now-1h',
-    end: 'now',
-    label: 'Last hour',
-  },
-  {
-    start: 'now-24h',
-    end: 'now',
-    label: 'Last 24 hours',
-  },
-  {
-    start: 'now-1w',
-    end: 'now',
-    label: 'Last 7 days',
-  },
-  {
-    start: 'now-30d',
-    end: 'now',
-    label: 'Last 30 days',
-  },
-];
-
-interface TimeRange {
-  start: string;
-  end: string;
-  isoStart: string;
-  isoEnd: string;
-  unixStart: number;
-  unixEnd: number;
-}
-
-function buildTimeRange(start: string, end: string): TimeRange {
-  const timeStart = dateMath.parse(start);
-  const timeEnd = dateMath.parse(end);
-  return {
-    start,
-    end,
-    isoStart: timeStart.toISOString(),
-    isoEnd: timeEnd.toISOString(),
-    unixStart: timeStart.utc().unix(),
-    unixEnd: timeEnd.utc().unix(),
-  };
-}
-
-export const FlameGraphNavigation = ({ index, projectID, n, getter, setter }) => {
-  const defaultTimeRange = buildTimeRange(commonlyUsedRanges[0].start, commonlyUsedRanges[0].end);
-  const [timeRange, setTimeRange] = useState(defaultTimeRange);
-
-  const handleTimeChange = (selectedTime: { start: string; end: string; isInvalid: boolean }) => {
-    if (selectedTime.isInvalid) {
-      return;
-    }
-
-    const tr = buildTimeRange(selectedTime.start, selectedTime.end);
-    setTimeRange(tr);
-  };
-
+export const FlameGraphNavigation = ({ index, projectID, n, timeRange, getter, setter }) => {
   useEffect(() => {
     console.log(new Date().toISOString(), timeRange);
     console.log(new Date().toISOString(), 'started payload retrieval');
@@ -88,17 +17,7 @@ export const FlameGraphNavigation = ({ index, projectID, n, getter, setter }) =>
       setter(response);
       console.log(new Date().toISOString(), 'updated local state');
     });
-  }, [projectID, timeRange]);
+  }, [index, projectID, n, timeRange]);
 
-  return (
-    <div>
-      <EuiSuperDatePicker
-        start={timeRange.start}
-        end={timeRange.end}
-        isPaused={true}
-        onTimeChange={handleTimeChange}
-        commonlyUsedRanges={commonlyUsedRanges}
-      />
-    </div>
-  );
+  return <></>;
 };

--- a/src/plugins/profiling/public/components/flamegraph-nav.tsx
+++ b/src/plugins/profiling/public/components/flamegraph-nav.tsx
@@ -83,7 +83,7 @@ export const FlameGraphNavigation = ({ getter, setter }) => {
   useEffect(() => {
     console.log(new Date().toISOString(), timeRange);
     console.log(new Date().toISOString(), 'started payload retrieval');
-    getter(timeRange.unixStart, timeRange.unixEnd).then((response) => {
+    getter(5, timeRange.unixStart, timeRange.unixEnd).then((response) => {
       console.log(new Date().toISOString(), 'finished payload retrieval');
       setter(response);
       console.log(new Date().toISOString(), 'updated local state');

--- a/src/plugins/profiling/public/components/flamegraph-nav.tsx
+++ b/src/plugins/profiling/public/components/flamegraph-nav.tsx
@@ -67,7 +67,7 @@ function buildTimeRange(start: string, end: string): TimeRange {
   };
 }
 
-export const FlameGraphNavigation = ({ index, projectID, getter, setter }) => {
+export const FlameGraphNavigation = ({ index, projectID, n, getter, setter }) => {
   const defaultTimeRange = buildTimeRange(commonlyUsedRanges[0].start, commonlyUsedRanges[0].end);
   const [timeRange, setTimeRange] = useState(defaultTimeRange);
 
@@ -83,7 +83,7 @@ export const FlameGraphNavigation = ({ index, projectID, getter, setter }) => {
   useEffect(() => {
     console.log(new Date().toISOString(), timeRange);
     console.log(new Date().toISOString(), 'started payload retrieval');
-    getter(index, projectID, timeRange.unixStart, timeRange.unixEnd).then((response) => {
+    getter(index, projectID, timeRange.unixStart, timeRange.unixEnd, n).then((response) => {
       console.log(new Date().toISOString(), 'finished payload retrieval');
       setter(response);
       console.log(new Date().toISOString(), 'updated local state');

--- a/src/plugins/profiling/public/components/flamegraph-nav.tsx
+++ b/src/plugins/profiling/public/components/flamegraph-nav.tsx
@@ -67,7 +67,7 @@ function buildTimeRange(start: string, end: string): TimeRange {
   };
 }
 
-export const FlameGraphNavigation = ({ projectID, getter, setter }) => {
+export const FlameGraphNavigation = ({ index, projectID, getter, setter }) => {
   const defaultTimeRange = buildTimeRange(commonlyUsedRanges[0].start, commonlyUsedRanges[0].end);
   const [timeRange, setTimeRange] = useState(defaultTimeRange);
 
@@ -83,7 +83,7 @@ export const FlameGraphNavigation = ({ projectID, getter, setter }) => {
   useEffect(() => {
     console.log(new Date().toISOString(), timeRange);
     console.log(new Date().toISOString(), 'started payload retrieval');
-    getter(projectID, timeRange.unixStart, timeRange.unixEnd).then((response) => {
+    getter(index, projectID, timeRange.unixStart, timeRange.unixEnd).then((response) => {
       console.log(new Date().toISOString(), 'finished payload retrieval');
       setter(response);
       console.log(new Date().toISOString(), 'updated local state');

--- a/src/plugins/profiling/public/components/flamegraph-nav.tsx
+++ b/src/plugins/profiling/public/components/flamegraph-nav.tsx
@@ -67,7 +67,7 @@ function buildTimeRange(start: string, end: string): TimeRange {
   };
 }
 
-export const FlameGraphNavigation = ({ getter, setter }) => {
+export const FlameGraphNavigation = ({ projectID, getter, setter }) => {
   const defaultTimeRange = buildTimeRange(commonlyUsedRanges[0].start, commonlyUsedRanges[0].end);
   const [timeRange, setTimeRange] = useState(defaultTimeRange);
 
@@ -83,12 +83,12 @@ export const FlameGraphNavigation = ({ getter, setter }) => {
   useEffect(() => {
     console.log(new Date().toISOString(), timeRange);
     console.log(new Date().toISOString(), 'started payload retrieval');
-    getter(5, timeRange.unixStart, timeRange.unixEnd).then((response) => {
+    getter(projectID, timeRange.unixStart, timeRange.unixEnd).then((response) => {
       console.log(new Date().toISOString(), 'finished payload retrieval');
       setter(response);
       console.log(new Date().toISOString(), 'updated local state');
     });
-  }, [timeRange]);
+  }, [projectID, timeRange]);
 
   return (
     <div>

--- a/src/plugins/profiling/public/components/settings-flyout.tsx
+++ b/src/plugins/profiling/public/components/settings-flyout.tsx
@@ -26,6 +26,8 @@ import {
 } from '@elastic/eui';
 
 interface SettingsFlyoutProps {
+  title: string;
+
   defaultIndex: string;
   updateIndex: (idx: string) => void;
 
@@ -37,6 +39,7 @@ interface SettingsFlyoutProps {
 }
 
 export function SettingsFlyout({
+  title,
   defaultIndex,
   updateIndex,
   defaultProjectID,
@@ -70,12 +73,12 @@ export function SettingsFlyout({
 
   return (
     <div>
-      <EuiButton onClick={showFlyout}>Settings</EuiButton>
+      <EuiButton onClick={showFlyout}>{title}</EuiButton>
       {isFlyoutVisible && (
         <EuiFlyout ownFocus onClose={closeFlyout} hideCloseButton aria-labelledby={flyoutTitleId}>
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="m">
-              <h2 id={flyoutTitleId}>Settings</h2>
+              <h2 id={flyoutTitleId}>{title}</h2>
             </EuiTitle>
             <EuiSpacer size="s" />
           </EuiFlyoutHeader>

--- a/src/plugins/profiling/public/components/settings-flyout.tsx
+++ b/src/plugins/profiling/public/components/settings-flyout.tsx
@@ -31,6 +31,9 @@ interface SettingsFlyoutProps {
 
   defaultProjectID: number;
   updateProjectID: (n: number) => void;
+
+  defaultN: number;
+  updateN: (n: number) => void;
 }
 
 export function SettingsFlyout({
@@ -38,9 +41,13 @@ export function SettingsFlyout({
   updateIndex,
   defaultProjectID,
   updateProjectID,
+  defaultN,
+  updateN,
 }: SettingsFlyoutProps) {
   const [index, setIndex] = useState(defaultIndex);
   const [projectID, setProjectID] = useState(defaultProjectID);
+  const [n, setN] = useState(defaultN);
+
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const flyoutTitleId = useGeneratedHtmlId({
     prefix: 'settings',
@@ -53,11 +60,13 @@ export function SettingsFlyout({
   const saveFlyout = () => {
     updateIndex(index);
     updateProjectID(projectID);
+    updateN(n);
     setIsFlyoutVisible(false);
   };
 
   const onIndexChange = (e: any) => setIndex(e.target.value);
   const onProjectIDChange = (e: any) => setProjectID(e.target.value);
+  const onNChange = (e: any) => setN(e.target.value);
 
   return (
     <div>
@@ -77,6 +86,9 @@ export function SettingsFlyout({
               </EuiFormRow>
               <EuiFormRow label="Project ID">
                 <EuiFieldText name="projectID" value={projectID} onChange={onProjectIDChange} />
+              </EuiFormRow>
+              <EuiFormRow label="N">
+                <EuiFieldText name="n" value={n} onChange={onNChange} />
               </EuiFormRow>
             </EuiForm>
           </EuiFlyoutBody>

--- a/src/plugins/profiling/public/components/settings-flyout.tsx
+++ b/src/plugins/profiling/public/components/settings-flyout.tsx
@@ -84,13 +84,22 @@ export function SettingsFlyout({
           </EuiFlyoutHeader>
           <EuiFlyoutBody>
             <EuiForm component="form">
-              <EuiFormRow label="Index">
+              <EuiFormRow
+                label="Index"
+                helpText="This is the primary Elasticsearch index used before sampling."
+              >
                 <EuiFieldText name="index" value={index} onChange={onIndexChange} />
               </EuiFormRow>
-              <EuiFormRow label="Project ID">
+              <EuiFormRow
+                label="Project ID"
+                helpText="This is the project ID as defined by the host agent."
+              >
                 <EuiFieldText name="projectID" value={projectID} onChange={onProjectIDChange} />
               </EuiFormRow>
-              <EuiFormRow label="N">
+              <EuiFormRow
+                label="N"
+                helpText="This is the maximum number of items per histogram bucket (Stack Traces) or is currently ignored (FlameGraph)."
+              >
                 <EuiFieldText name="n" value={n} onChange={onNChange} />
               </EuiFormRow>
             </EuiForm>

--- a/src/plugins/profiling/public/components/settings-flyout.tsx
+++ b/src/plugins/profiling/public/components/settings-flyout.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useState } from 'react';
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFieldText,
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiForm,
+  EuiFormRow,
+  EuiSpacer,
+  EuiTitle,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+
+interface SettingsFlyoutProps {
+  defaultProjectID: number;
+  updateProjectID: (n: number) => void;
+}
+
+export function SettingsFlyout({ defaultProjectID, updateProjectID }: SettingsFlyoutProps) {
+  const [projectID, setProjectID] = useState(defaultProjectID);
+  const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+  const flyoutTitleId = useGeneratedHtmlId({
+    prefix: 'settings',
+  });
+
+  const showFlyout = () => setIsFlyoutVisible(true);
+
+  const closeFlyout = () => setIsFlyoutVisible(false);
+
+  const saveFlyout = () => {
+    updateProjectID(projectID);
+    setIsFlyoutVisible(false);
+  };
+
+  const onProjectIDChange = (e: any) => setProjectID(e.target.value);
+
+  return (
+    <div>
+      <EuiButton onClick={showFlyout}>Settings</EuiButton>
+      {isFlyoutVisible && (
+        <EuiFlyout ownFocus onClose={closeFlyout} hideCloseButton aria-labelledby={flyoutTitleId}>
+          <EuiFlyoutHeader hasBorder>
+            <EuiTitle size="m">
+              <h2 id={flyoutTitleId}>Settings</h2>
+            </EuiTitle>
+            <EuiSpacer size="s" />
+          </EuiFlyoutHeader>
+          <EuiFlyoutBody>
+            <EuiForm component="form">
+              <EuiFormRow label="Project ID">
+                <EuiFieldText name="projectID" value={projectID} onChange={onProjectIDChange} />
+              </EuiFormRow>
+            </EuiForm>
+          </EuiFlyoutBody>
+          <EuiFlyoutFooter>
+            <EuiFlexGroup justifyContent="spaceBetween">
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty iconType="cross" onClick={closeFlyout} flush="left">
+                  Close
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton onClick={saveFlyout} fill>
+                  Save
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlyoutFooter>
+        </EuiFlyout>
+      )}
+    </div>
+  );
+}

--- a/src/plugins/profiling/public/components/settings-flyout.tsx
+++ b/src/plugins/profiling/public/components/settings-flyout.tsx
@@ -26,11 +26,20 @@ import {
 } from '@elastic/eui';
 
 interface SettingsFlyoutProps {
+  defaultIndex: string;
+  updateIndex: (idx: string) => void;
+
   defaultProjectID: number;
   updateProjectID: (n: number) => void;
 }
 
-export function SettingsFlyout({ defaultProjectID, updateProjectID }: SettingsFlyoutProps) {
+export function SettingsFlyout({
+  defaultIndex,
+  updateIndex,
+  defaultProjectID,
+  updateProjectID,
+}: SettingsFlyoutProps) {
+  const [index, setIndex] = useState(defaultIndex);
   const [projectID, setProjectID] = useState(defaultProjectID);
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const flyoutTitleId = useGeneratedHtmlId({
@@ -42,10 +51,12 @@ export function SettingsFlyout({ defaultProjectID, updateProjectID }: SettingsFl
   const closeFlyout = () => setIsFlyoutVisible(false);
 
   const saveFlyout = () => {
+    updateIndex(index);
     updateProjectID(projectID);
     setIsFlyoutVisible(false);
   };
 
+  const onIndexChange = (e: any) => setIndex(e.target.value);
   const onProjectIDChange = (e: any) => setProjectID(e.target.value);
 
   return (
@@ -61,6 +72,9 @@ export function SettingsFlyout({ defaultProjectID, updateProjectID }: SettingsFl
           </EuiFlyoutHeader>
           <EuiFlyoutBody>
             <EuiForm component="form">
+              <EuiFormRow label="Index">
+                <EuiFieldText name="index" value={index} onChange={onIndexChange} />
+              </EuiFormRow>
               <EuiFormRow label="Project ID">
                 <EuiFieldText name="projectID" value={projectID} onChange={onProjectIDChange} />
               </EuiFormRow>

--- a/src/plugins/profiling/public/components/stacktrace-nav.tsx
+++ b/src/plugins/profiling/public/components/stacktrace-nav.tsx
@@ -12,7 +12,7 @@ import { EuiButtonGroup, EuiSpacer } from '@elastic/eui';
 
 import { getTopN, groupSamplesByCategory } from '../../common';
 
-export const StackTraceNavigation = ({ fetchTopN, setTopN }) => {
+export const StackTraceNavigation = ({ projectID, fetchTopN, setTopN }) => {
   const topnButtonGroupPrefix = 'topnButtonGroup';
 
   const topnButtons = [
@@ -101,14 +101,14 @@ export const StackTraceNavigation = ({ fetchTopN, setTopN }) => {
     });
 
     console.log(new Date().toISOString(), 'started payload retrieval');
-    fetchTopN(5, topnValue[0].value, dateValue[0].value).then((response) => {
+    fetchTopN(projectID, topnValue[0].value, dateValue[0].value).then((response) => {
       console.log(new Date().toISOString(), 'finished payload retrieval');
       const samples = getTopN(response);
       const series = groupSamplesByCategory(samples);
       setTopN({ samples, series });
       console.log(new Date().toISOString(), 'updated local state');
     });
-  }, [toggleTopNSelected, toggleDateSelected]);
+  }, [projectID, toggleTopNSelected, toggleDateSelected]);
 
   return (
     <div>

--- a/src/plugins/profiling/public/components/stacktrace-nav.tsx
+++ b/src/plugins/profiling/public/components/stacktrace-nav.tsx
@@ -101,7 +101,7 @@ export const StackTraceNavigation = ({ fetchTopN, setTopN }) => {
     });
 
     console.log(new Date().toISOString(), 'started payload retrieval');
-    fetchTopN(topnValue[0].value, dateValue[0].value).then((response) => {
+    fetchTopN(5, topnValue[0].value, dateValue[0].value).then((response) => {
       console.log(new Date().toISOString(), 'finished payload retrieval');
       const samples = getTopN(response);
       const series = groupSamplesByCategory(samples);

--- a/src/plugins/profiling/public/components/stacktrace-nav.tsx
+++ b/src/plugins/profiling/public/components/stacktrace-nav.tsx
@@ -12,7 +12,7 @@ import { EuiButtonGroup, EuiSpacer } from '@elastic/eui';
 
 import { getTopN, groupSamplesByCategory } from '../../common';
 
-export const StackTraceNavigation = ({ index, projectID, fetchTopN, setTopN }) => {
+export const StackTraceNavigation = ({ index, projectID, n, fetchTopN, setTopN }) => {
   const topnButtonGroupPrefix = 'topnButtonGroup';
 
   const topnButtons = [
@@ -101,7 +101,7 @@ export const StackTraceNavigation = ({ index, projectID, fetchTopN, setTopN }) =
     });
 
     console.log(new Date().toISOString(), 'started payload retrieval');
-    fetchTopN(index, projectID, topnValue[0].value, dateValue[0].value).then((response) => {
+    fetchTopN(index, projectID, topnValue[0].value, dateValue[0].value, n).then((response) => {
       console.log(new Date().toISOString(), 'finished payload retrieval');
       const samples = getTopN(response);
       const series = groupSamplesByCategory(samples);

--- a/src/plugins/profiling/public/components/stacktrace-nav.tsx
+++ b/src/plugins/profiling/public/components/stacktrace-nav.tsx
@@ -12,7 +12,7 @@ import { EuiButtonGroup, EuiSpacer } from '@elastic/eui';
 
 import { getTopN, groupSamplesByCategory } from '../../common';
 
-export const StackTraceNavigation = ({ projectID, fetchTopN, setTopN }) => {
+export const StackTraceNavigation = ({ index, projectID, fetchTopN, setTopN }) => {
   const topnButtonGroupPrefix = 'topnButtonGroup';
 
   const topnButtons = [
@@ -101,7 +101,7 @@ export const StackTraceNavigation = ({ projectID, fetchTopN, setTopN }) => {
     });
 
     console.log(new Date().toISOString(), 'started payload retrieval');
-    fetchTopN(projectID, topnValue[0].value, dateValue[0].value).then((response) => {
+    fetchTopN(index, projectID, topnValue[0].value, dateValue[0].value).then((response) => {
       console.log(new Date().toISOString(), 'finished payload retrieval');
       const samples = getTopN(response);
       const series = groupSamplesByCategory(samples);

--- a/src/plugins/profiling/public/components/stacktrace-nav.tsx
+++ b/src/plugins/profiling/public/components/stacktrace-nav.tsx
@@ -8,11 +8,11 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { EuiButtonGroup, EuiSpacer } from '@elastic/eui';
+import { EuiButtonGroup } from '@elastic/eui';
 
 import { getTopN, groupSamplesByCategory } from '../../common';
 
-export const StackTraceNavigation = ({ index, projectID, n, fetchTopN, setTopN }) => {
+export const StackTraceNavigation = ({ index, projectID, n, timeRange, fetchTopN, setTopN }) => {
   const topnButtonGroupPrefix = 'topnButtonGroup';
 
   const topnButtons = [
@@ -52,63 +52,22 @@ export const StackTraceNavigation = ({ index, projectID, n, fetchTopN, setTopN }
     setToggleTopNSelected(optionId);
   };
 
-  const dateButtonGroupPrefix = 'dateButtonGroup';
-
-  const dateButtons = [
-    {
-      id: `${dateButtonGroupPrefix}__0`,
-      label: '30m',
-      value: '1800',
-    },
-    {
-      id: `${dateButtonGroupPrefix}__1`,
-      label: '1h',
-      value: '3600',
-    },
-    {
-      id: `${dateButtonGroupPrefix}__2`,
-      label: '24h',
-      value: '86400',
-    },
-    {
-      id: `${dateButtonGroupPrefix}__3`,
-      label: '7d',
-      value: '604800',
-    },
-    {
-      id: `${dateButtonGroupPrefix}__4`,
-      label: '30d',
-      value: '2592000',
-    },
-  ];
-
-  const [toggleDateSelected, setToggleDateSelected] = useState(`${dateButtonGroupPrefix}__0`);
-
-  const onDateChange = (optionId: string) => {
-    if (optionId === toggleDateSelected) {
-      return;
-    }
-    setToggleDateSelected(optionId);
-  };
-
   useEffect(() => {
     const topnValue = topnButtons.filter((button) => {
       return button.id === toggleTopNSelected;
     });
 
-    const dateValue = dateButtons.filter((button) => {
-      return button.id === toggleDateSelected;
-    });
-
     console.log(new Date().toISOString(), 'started payload retrieval');
-    fetchTopN(index, projectID, topnValue[0].value, dateValue[0].value, n).then((response) => {
-      console.log(new Date().toISOString(), 'finished payload retrieval');
-      const samples = getTopN(response);
-      const series = groupSamplesByCategory(samples);
-      setTopN({ samples, series });
-      console.log(new Date().toISOString(), 'updated local state');
-    });
-  }, [projectID, toggleTopNSelected, toggleDateSelected]);
+    fetchTopN(topnValue[0].value, index, projectID, timeRange.unixStart, timeRange.unixEnd, n).then(
+      (response) => {
+        console.log(new Date().toISOString(), 'finished payload retrieval');
+        const samples = getTopN(response);
+        const series = groupSamplesByCategory(samples);
+        setTopN({ samples, series });
+        console.log(new Date().toISOString(), 'updated local state');
+      }
+    );
+  }, [index, projectID, n, timeRange, toggleTopNSelected]);
 
   return (
     <div>
@@ -117,13 +76,6 @@ export const StackTraceNavigation = ({ index, projectID, n, fetchTopN, setTopN }
         options={topnButtons}
         idSelected={toggleTopNSelected}
         onChange={(id) => onTopNChange(id)}
-      />
-      <EuiSpacer size="s" />
-      <EuiButtonGroup
-        legend="This is a basic group"
-        options={dateButtons}
-        idSelected={toggleDateSelected}
-        onChange={(id) => onDateChange(id)}
       />
     </div>
   );

--- a/src/plugins/profiling/public/services.ts
+++ b/src/plugins/profiling/public/services.ts
@@ -10,18 +10,20 @@ import { CoreStart, HttpFetchError, HttpFetchQuery } from 'kibana/public';
 import { getRoutePaths } from '../common';
 
 export interface Services {
-  fetchTopN: (projectID: number, type: string, seconds: string) => Promise<any[] | HttpFetchError>;
-  fetchElasticFlamechart: (
+  fetchTopN: (
+    index: string,
     projectID: number,
-    timeFrom: number,
-    timeTo: number
+    type: string,
+    seconds: string
   ) => Promise<any[] | HttpFetchError>;
-  fetchElasticFlamechart2: (
+  fetchElasticFlamechart: (
+    index: string,
     projectID: number,
     timeFrom: number,
     timeTo: number
   ) => Promise<any[] | HttpFetchError>;
   fetchPixiFlamechart: (
+    index: string,
     projectID: number,
     timeFrom: number,
     timeTo: number
@@ -32,11 +34,11 @@ export function getServices(core: CoreStart): Services {
   const paths = getRoutePaths();
 
   return {
-    fetchTopN: async (projectID: number, type: string, seconds: string) => {
+    fetchTopN: async (index: string, projectID: number, type: string, seconds: string) => {
       try {
         const unixTime = Math.floor(Date.now() / 1000);
         const query: HttpFetchQuery = {
-          index: 'profiling-events-all',
+          index,
           projectID,
           timeFrom: unixTime - parseInt(seconds, 10),
           timeTo: unixTime,
@@ -49,10 +51,15 @@ export function getServices(core: CoreStart): Services {
       }
     },
 
-    fetchElasticFlamechart: async (projectID: number, timeFrom: number, timeTo: number) => {
+    fetchElasticFlamechart: async (
+      index: string,
+      projectID: number,
+      timeFrom: number,
+      timeTo: number
+    ) => {
       try {
         const query: HttpFetchQuery = {
-          index: 'profiling-events-all',
+          index,
           projectID,
           timeFrom,
           timeTo,
@@ -65,26 +72,15 @@ export function getServices(core: CoreStart): Services {
       }
     },
 
-    fetchElasticFlamechart2: async (projectID: number, timeFrom: number, timeTo: number) => {
+    fetchPixiFlamechart: async (
+      index: string,
+      projectID: number,
+      timeFrom: number,
+      timeTo: number
+    ) => {
       try {
         const query: HttpFetchQuery = {
-          index: 'profiling-events2',
-          projectID,
-          timeFrom,
-          timeTo,
-          // TODO remove hard-coded value for topN items length and expose it through the UI
-          n: 100,
-        };
-        return await core.http.get(paths.FlamechartElastic, { query });
-      } catch (e) {
-        return e;
-      }
-    },
-
-    fetchPixiFlamechart: async (projectID: number, timeFrom: number, timeTo: number) => {
-      try {
-        const query: HttpFetchQuery = {
-          index: 'profiling-events-all',
+          index,
           projectID,
           timeFrom,
           timeTo,

--- a/src/plugins/profiling/public/services.ts
+++ b/src/plugins/profiling/public/services.ts
@@ -14,19 +14,22 @@ export interface Services {
     index: string,
     projectID: number,
     type: string,
-    seconds: string
+    seconds: string,
+    n: number
   ) => Promise<any[] | HttpFetchError>;
   fetchElasticFlamechart: (
     index: string,
     projectID: number,
     timeFrom: number,
-    timeTo: number
+    timeTo: number,
+    n: number
   ) => Promise<any[] | HttpFetchError>;
   fetchPixiFlamechart: (
     index: string,
     projectID: number,
     timeFrom: number,
-    timeTo: number
+    timeTo: number,
+    n: number
   ) => Promise<any[] | HttpFetchError>;
 }
 
@@ -34,7 +37,13 @@ export function getServices(core: CoreStart): Services {
   const paths = getRoutePaths();
 
   return {
-    fetchTopN: async (index: string, projectID: number, type: string, seconds: string) => {
+    fetchTopN: async (
+      index: string,
+      projectID: number,
+      type: string,
+      seconds: string,
+      n: number
+    ) => {
       try {
         const unixTime = Math.floor(Date.now() / 1000);
         const query: HttpFetchQuery = {
@@ -42,8 +51,7 @@ export function getServices(core: CoreStart): Services {
           projectID,
           timeFrom: unixTime - parseInt(seconds, 10),
           timeTo: unixTime,
-          // TODO remove hard-coded value for topN items length and expose it through the UI
-          n: 100,
+          n,
         };
         return await core.http.get(`${paths.TopN}/${type}`, { query });
       } catch (e) {
@@ -55,7 +63,8 @@ export function getServices(core: CoreStart): Services {
       index: string,
       projectID: number,
       timeFrom: number,
-      timeTo: number
+      timeTo: number,
+      n: number
     ) => {
       try {
         const query: HttpFetchQuery = {
@@ -63,8 +72,7 @@ export function getServices(core: CoreStart): Services {
           projectID,
           timeFrom,
           timeTo,
-          // TODO remove hard-coded value for topN items length and expose it through the UI
-          n: 100,
+          n,
         };
         return await core.http.get(paths.FlamechartElastic, { query });
       } catch (e) {
@@ -76,7 +84,8 @@ export function getServices(core: CoreStart): Services {
       index: string,
       projectID: number,
       timeFrom: number,
-      timeTo: number
+      timeTo: number,
+      n: number
     ) => {
       try {
         const query: HttpFetchQuery = {
@@ -84,8 +93,7 @@ export function getServices(core: CoreStart): Services {
           projectID,
           timeFrom,
           timeTo,
-          // TODO remove hard-coded value for topN items length and expose it through the UI
-          n: 100,
+          n,
         };
         return await core.http.get(paths.FlamechartPixi, { query });
       } catch (e) {

--- a/src/plugins/profiling/public/services.ts
+++ b/src/plugins/profiling/public/services.ts
@@ -11,10 +11,11 @@ import { getRoutePaths } from '../common';
 
 export interface Services {
   fetchTopN: (
+    type: string,
     index: string,
     projectID: number,
-    type: string,
-    seconds: string,
+    timeFrom: number,
+    timeTo: number,
     n: number
   ) => Promise<any[] | HttpFetchError>;
   fetchElasticFlamechart: (
@@ -38,19 +39,19 @@ export function getServices(core: CoreStart): Services {
 
   return {
     fetchTopN: async (
+      type: string,
       index: string,
       projectID: number,
-      type: string,
-      seconds: string,
+      timeFrom: number,
+      timeTo: number,
       n: number
     ) => {
       try {
-        const unixTime = Math.floor(Date.now() / 1000);
         const query: HttpFetchQuery = {
           index,
           projectID,
-          timeFrom: unixTime - parseInt(seconds, 10),
-          timeTo: unixTime,
+          timeFrom,
+          timeTo,
           n,
         };
         return await core.http.get(`${paths.TopN}/${type}`, { query });

--- a/src/plugins/profiling/public/services.ts
+++ b/src/plugins/profiling/public/services.ts
@@ -10,22 +10,34 @@ import { CoreStart, HttpFetchError, HttpFetchQuery } from 'kibana/public';
 import { getRoutePaths } from '../common';
 
 export interface Services {
-  fetchTopN: (type: string, seconds: string) => Promise<any[] | HttpFetchError>;
-  fetchElasticFlamechart: (timeFrom: number, timeTo: number) => Promise<any[] | HttpFetchError>;
-  fetchElasticFlamechart2: (timeFrom: number, timeTo: number) => Promise<any[] | HttpFetchError>;
-  fetchPixiFlamechart: (timeFrom: number, timeTo: number) => Promise<any[] | HttpFetchError>;
+  fetchTopN: (projectID: number, type: string, seconds: string) => Promise<any[] | HttpFetchError>;
+  fetchElasticFlamechart: (
+    projectID: number,
+    timeFrom: number,
+    timeTo: number
+  ) => Promise<any[] | HttpFetchError>;
+  fetchElasticFlamechart2: (
+    projectID: number,
+    timeFrom: number,
+    timeTo: number
+  ) => Promise<any[] | HttpFetchError>;
+  fetchPixiFlamechart: (
+    projectID: number,
+    timeFrom: number,
+    timeTo: number
+  ) => Promise<any[] | HttpFetchError>;
 }
 
 export function getServices(core: CoreStart): Services {
   const paths = getRoutePaths();
 
   return {
-    fetchTopN: async (type: string, seconds: string) => {
+    fetchTopN: async (projectID: number, type: string, seconds: string) => {
       try {
         const unixTime = Math.floor(Date.now() / 1000);
         const query: HttpFetchQuery = {
           index: 'profiling-events-all',
-          projectID: 5,
+          projectID,
           timeFrom: unixTime - parseInt(seconds, 10),
           timeTo: unixTime,
           // TODO remove hard-coded value for topN items length and expose it through the UI
@@ -37,11 +49,11 @@ export function getServices(core: CoreStart): Services {
       }
     },
 
-    fetchElasticFlamechart: async (timeFrom: number, timeTo: number) => {
+    fetchElasticFlamechart: async (projectID: number, timeFrom: number, timeTo: number) => {
       try {
         const query: HttpFetchQuery = {
           index: 'profiling-events-all',
-          projectID: 5,
+          projectID,
           timeFrom,
           timeTo,
           // TODO remove hard-coded value for topN items length and expose it through the UI
@@ -53,11 +65,11 @@ export function getServices(core: CoreStart): Services {
       }
     },
 
-    fetchElasticFlamechart2: async (timeFrom: number, timeTo: number) => {
+    fetchElasticFlamechart2: async (projectID: number, timeFrom: number, timeTo: number) => {
       try {
         const query: HttpFetchQuery = {
           index: 'profiling-events2',
-          projectID: 5,
+          projectID,
           timeFrom,
           timeTo,
           // TODO remove hard-coded value for topN items length and expose it through the UI
@@ -69,11 +81,11 @@ export function getServices(core: CoreStart): Services {
       }
     },
 
-    fetchPixiFlamechart: async (timeFrom: number, timeTo: number) => {
+    fetchPixiFlamechart: async (projectID: number, timeFrom: number, timeTo: number) => {
       try {
         const query: HttpFetchQuery = {
           index: 'profiling-events-all',
-          projectID: 5,
+          projectID,
           timeFrom,
           timeTo,
           // TODO remove hard-coded value for topN items length and expose it through the UI


### PR DESCRIPTION
This PR updates the UI so that we can configure previously hardcoded request parameters (`projectID`, `index`, `n`) and also configure the date for all charts.

Features:
- No more hardcoded values in UI
- Add page title
- Add popup window to configure common settings, especially for request parameters (`projectID`, `index`, `n`)
- Use Elastic date picker for stack traces and all flamegraphs
- Elastic date picker is now globally accessible across all tabs
- Removed duplicate second Elastic flamegraph since `index` is configurable in UI

**New configuration for stack traces and flamegraphs**

![image](https://user-images.githubusercontent.com/6038/165374882-8ed5e3b4-1059-48af-8efc-614822e66d61.png)

**New configuration for stack traces and flamegraphs with open settings window**

![image](https://user-images.githubusercontent.com/6038/165374929-7ed586bb-985c-4960-9053-fac99a20254c.png)