### PR TITLE
Faster TopN aggregations /w execution_hint:map

### DIFF
--- a/src/plugins/profiling/server/routes/mappings.ts
+++ b/src/plugins/profiling/server/routes/mappings.ts
@@ -76,6 +76,9 @@ export function autoHistogramSumCountOnGroupByField(
           // of matched documents. This is not equal to the ordering by sum of Count field,
           // but it's a good-enough approximation given the distribution of Count.
           size: topNItems,
+          // 'execution_hint: map' skips the slow building of ordinals that we don't need.
+          // Especially with high cardinality fields, this setting speeds up the aggregation.
+          execution_hint: 'map',
         },
         aggs: {
           count: {


### PR DESCRIPTION
Speed up the TopN aggregations by applying `execution_hint: map` as we did in #66.
This drastically speeds up aggregations for high cardinality fields, in our case it is `StackTraceID`.

The second commit fixes the aggregation of `totalCount` (counting events) and also prints the total number of documents (`totalDocCount`).

We also should discuss this comment in `mappings.ts`:
```
          // We remove the ordering since we will rely directly on the natural
          // ordering of Elasticsearch: by default this will be the descending count
          // of matched documents. This is not equal to the ordering by sum of Count field,
          // but it's a good-enough approximation given the distribution of Count.
          size: topNItems,
```
IMO, we can not rely on that the mentioned approximation is "good enough".
In case we have some math to prove it, we should add a link.
