### PR TITLE
Fix broken TopN test

### DIFF
--- a/src/plugins/profiling/server/routes/topn.test.ts
+++ b/src/plugins/profiling/server/routes/topn.test.ts
@@ -35,8 +35,8 @@ describe('TopN data from Elasticsearch', () => {
   });
 
   describe('when fetching Stack Traces', () => {
-    it('should search first then mget', async () => {
-      await topNElasticSearchQuery(
+    it('should search first then skip mget', async () => {
+      const response = await topNElasticSearchQuery(
         client,
         logger,
         index,
@@ -47,8 +47,14 @@ describe('TopN data from Elasticsearch', () => {
         'StackTraceID',
         kibanaResponseFactory
       );
+
+      // Calls to mget are skipped since data doesn't exist
       expect(client.search).toHaveBeenCalledTimes(2);
-      expect(client.mget).toHaveBeenCalledTimes(2);
+      expect(client.mget).toHaveBeenCalledTimes(0);
+
+      expect(response.status).toEqual(200);
+      expect(response.payload).toHaveProperty('TopN');
+      expect(response.payload).toHaveProperty('Metadata');
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes the failing Top N test for stacktraces.

We had previously assumed that `mget` calls would always happen. However, if there was no data from the initial `search` calls, then `mget` would not be called, thus, the assertion failed.

Since we are making calls that return no data, I changed the assertion. I also checked if the response was valid (expected status code, expected data type in the payload).