### PR TITLE
Bump elastic-charts to 46.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@elastic/apm-rum": "^5.10.2",
     "@elastic/apm-rum-react": "^1.3.4",
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
-    "@elastic/charts": "46.8.0",
+    "@elastic/charts": "46.9.0",
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.2.0-canary.2",
     "@elastic/ems-client": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@elastic/apm-rum": "^5.10.2",
     "@elastic/apm-rum-react": "^1.3.4",
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
-    "@elastic/charts": "46.7.0",
+    "@elastic/charts": "46.8.0",
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.2.0-canary.2",
     "@elastic/ems-client": "8.2.0",

--- a/src/plugins/profiling/public/components/bar-chart.tsx
+++ b/src/plugins/profiling/public/components/bar-chart.tsx
@@ -24,7 +24,7 @@ export interface BarChartProps {
 export const BarChart: React.FC<BarChartProps> = ({ id, name, height, data, x, y }) => {
   useEffect(() => {
     console.log(new Date().toISOString(), 'updated bar-chart');
-  });
+  }, [id, name, height, data, x, y]);
 
   return (
     <Chart size={{ height }}>

--- a/src/plugins/profiling/public/components/chart-grid.tsx
+++ b/src/plugins/profiling/public/components/chart-grid.tsx
@@ -62,9 +62,11 @@ export const ChartGrid: React.FC<ChartGridProps> = ({ maximum }) => {
     }
     return charts;
   };
+
   useEffect(() => {
     console.log(new Date().toISOString(), 'updated chart-grid');
-  });
+  }, [ctx]);
+
   return (
     <>
       <EuiSpacer />

--- a/src/plugins/profiling/public/components/flamegraph-nav.tsx
+++ b/src/plugins/profiling/public/components/flamegraph-nav.tsx
@@ -10,10 +10,10 @@ import React, { useEffect } from 'react';
 
 export const FlameGraphNavigation = ({ index, projectID, n, timeRange, getter, setter }) => {
   useEffect(() => {
-    console.log(new Date().toISOString(), timeRange);
     console.log(new Date().toISOString(), 'started payload retrieval');
     getter(index, projectID, timeRange.unixStart, timeRange.unixEnd, n).then((response) => {
       console.log(new Date().toISOString(), 'finished payload retrieval');
+      console.log(new Date().toISOString(), response);
       setter(response);
       console.log(new Date().toISOString(), 'updated local state');
     });

--- a/src/plugins/profiling/public/components/stacked-bar-chart.tsx
+++ b/src/plugins/profiling/public/components/stacked-bar-chart.tsx
@@ -32,9 +32,11 @@ export const StackedBarChart: React.FC<StackedBarChartProps> = ({
   category,
 }) => {
   const ctx = useContext(TopNContext);
+
   useEffect(() => {
     console.log(new Date().toISOString(), 'updated stacked-bar-chart');
-  });
+  }, [ctx, id, name, x, y, category]);
+
   return (
     <Chart size={{ height }}>
       <Settings showLegend={false} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,10 +1450,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@46.8.0":
-  version "46.8.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-46.8.0.tgz#daf691315439ac7a22b61345c1af97c6a298cab4"
-  integrity sha512-+J4ty+h+vINK6y3cdjiPl9wMciUkuMLpwNLhPnFV7uzC6d4JIozonrRLnHEKfmDALwVxSf/jA8MlPS4p8wq2mg==
+"@elastic/charts@46.9.0":
+  version "46.9.0"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-46.9.0.tgz#45a615eb84c81d8cc5219eaa4eef8f4761c9fc05"
+  integrity sha512-RVDNgg9bZIZoq/8sfRg6n9gXHPzs4n8bAJogxnzv73f4sLcdytGqjNbdDpbDO2MPRKnA7nN92/L0Ewkp7SiU0Q==
   dependencies:
     "@popperjs/core" "^2.4.0"
     bezier-easing "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,10 +1450,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@46.7.0":
-  version "46.7.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-46.7.0.tgz#e64255a59a77d7e8c18289c624c885ee4460d45e"
-  integrity sha512-RP55HSf8Jphf3qS+TCA7fVMCo238OxPJFOP85WpTnPNoPa0U/N20CrdZzhjtM5z2NptFpenAE5e8Ye7Te8fYxA==
+"@elastic/charts@46.8.0":
+  version "46.8.0"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-46.8.0.tgz#daf691315439ac7a22b61345c1af97c6a298cab4"
+  integrity sha512-+J4ty+h+vINK6y3cdjiPl9wMciUkuMLpwNLhPnFV7uzC6d4JIozonrRLnHEKfmDALwVxSf/jA8MlPS4p8wq2mg==
   dependencies:
     "@popperjs/core" "^2.4.0"
     bezier-easing "^2.1.0"


### PR DESCRIPTION
This PR upgrades the Elastic charts library to the latest version and has a few minor updates to the UI logging.