### PR TITLE
Normalize x-axis across TopN subcharts

### DIFF
--- a/src/plugins/profiling/common/index.ts
+++ b/src/plugins/profiling/common/index.ts
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import { TopNSample } from './topn';
+
 export const PLUGIN_ID = 'profiling';
 export const PLUGIN_NAME = 'profiling';
 
@@ -23,37 +25,15 @@ export function getRoutePaths() {
   };
 }
 
-function toMilliseconds(seconds: string): number {
-  return parseInt(seconds, 10) * 1000;
-}
-
-export function getTopN(obj: any) {
-  const data = [];
-
-  if (obj.TopN!) {
-    for (const x in obj.TopN) {
-      if (obj.TopN.hasOwnProperty(x)) {
-        const values = obj.TopN[x];
-        for (let i = 0; i < values.length; i++) {
-          const v = values[i];
-          data.push({ x: toMilliseconds(x), y: v.Count, g: v.Value });
-        }
-      }
-    }
-  }
-
-  return data;
-}
-
-export function groupSamplesByCategory(samples: any) {
+export function groupSamplesByCategory(samples: TopNSample[]) {
   const series = new Map();
   for (let i = 0; i < samples.length; i++) {
     const v = samples[i];
-    if (!series.has(v.g)) {
-      series.set(v.g, []);
+    if (!series.has(v.Category)) {
+      series.set(v.Category, []);
     }
-    const value = series.get(v.g);
-    value.push([v.x, v.y]);
+    const value = series.get(v.Category);
+    value.push([v.Timestamp, v.Count]);
   }
   return series;
 }

--- a/src/plugins/profiling/common/index.ts
+++ b/src/plugins/profiling/common/index.ts
@@ -6,8 +6,6 @@
  * Side Public License, v 1.
  */
 
-import { TopNSample } from './topn';
-
 export const PLUGIN_ID = 'profiling';
 export const PLUGIN_NAME = 'profiling';
 
@@ -23,19 +21,6 @@ export function getRoutePaths() {
     TopNTraces: `${BASE_ROUTE_PATH}/topn/traces`,
     FlamechartElastic: `${BASE_ROUTE_PATH}/flamechart/elastic`,
   };
-}
-
-export function groupSamplesByCategory(samples: TopNSample[]) {
-  const series = new Map();
-  for (let i = 0; i < samples.length; i++) {
-    const v = samples[i];
-    if (!series.has(v.Category)) {
-      series.set(v.Category, []);
-    }
-    const value = series.get(v.Category);
-    value.push([v.Timestamp, v.Count]);
-  }
-  return series;
 }
 
 export function timeRangeFromRequest(request: any): [number, number] {

--- a/src/plugins/profiling/common/index.ts
+++ b/src/plugins/profiling/common/index.ts
@@ -47,7 +47,7 @@ export function timeRangeFromRequest(request: any): [number, number] {
 // Converts from a Map object to a Record object since Map objects are not
 // serializable to JSON by default
 export function fromMapToRecord<K extends string, V>(m: Map<K, V>): Record<string, V> {
-  let output: Record<string, V> = {};
+  const output: Record<string, V> = {};
 
   for (const [key, value] of m) {
     output[key] = value;

--- a/src/plugins/profiling/common/topn.ts
+++ b/src/plugins/profiling/common/topn.ts
@@ -71,3 +71,16 @@ export function createTopNSamples(histogram: AggregationsHistogramAggregate): To
 
   return samples;
 }
+
+export function groupSamplesByCategory(samples: TopNSample[]) {
+  const series = new Map();
+  for (let i = 0; i < samples.length; i++) {
+    const v = samples[i];
+    if (!series.has(v.Category)) {
+      series.set(v.Category, []);
+    }
+    const value = series.get(v.Category);
+    value.push([v.Timestamp, v.Count]);
+  }
+  return series;
+}

--- a/src/plugins/profiling/common/topn.ts
+++ b/src/plugins/profiling/common/topn.ts
@@ -47,10 +47,12 @@ export function createTopNSamples(histogram: AggregationsHistogramAggregate): To
   const samples: TopNSample[] = [];
   for (const timestamp of bucketsByTimestamp.keys()) {
     for (const category of uniqueCategories.values()) {
-      const sample: TopNSample = { Timestamp: timestamp, Count: 0, Category: category };
-      if (bucketsByTimestamp.get(timestamp).has(category)) {
-        sample.Count = bucketsByTimestamp.get(timestamp).get(category);
-      }
+      const frameCountsByCategory = bucketsByTimestamp.get(timestamp);
+      const sample: TopNSample = {
+        Timestamp: timestamp,
+        Count: frameCountsByCategory.get(category) ?? 0,
+        Category: category
+      };
       samples.push(sample);
     }
   }

--- a/src/plugins/profiling/common/topn.ts
+++ b/src/plugins/profiling/common/topn.ts
@@ -61,9 +61,13 @@ export function createTopNSamples(histogram: AggregationsHistogramAggregate): To
   }
 
   // Sort by timestamp ascending, count descending, and category ascending
-  samples.sort(
-    (a, b) => a.Timestamp - b.Timestamp || b.Count - a.Count || a.Category.localeCompare(b.Category)
-  );
+  samples.sort((a, b) => {
+    if (a.Timestamp < b.Timestamp) return -1;
+    if (a.Timestamp > b.Timestamp) return 1;
+    if (a.Count > b.Count) return -1;
+    if (a.Count < b.Count) return 1;
+    return a.Category.localeCompare(b.Category);
+  });
 
   return samples;
 }

--- a/src/plugins/profiling/common/topn.ts
+++ b/src/plugins/profiling/common/topn.ts
@@ -13,26 +13,19 @@ import {
 
 import { StackFrameMetadata } from './profiling';
 
-export type TopNSample = {
+export interface TopNSample {
   Timestamp: number;
   Count: number;
   Category: string;
-};
+}
 
-export type TopNSamples = {
+export interface TopNSamples {
   TopN: TopNSample[];
-};
+}
 
-type TopNContainers = TopNSamples;
-type TopNDeployments = TopNSamples;
-type TopNHosts = TopNSamples;
-type TopNThreads = TopNSamples;
-
-type TopNTraces = TopNSamples & {
+interface TopNTraces extends TopNSamples {
   Metadata: Record<string, StackFrameMetadata[]>;
-};
-
-type TopN = TopNContainers | TopNDeployments | TopNHosts | TopNThreads | TopNTraces;
+}
 
 export function createTopNSamples(histogram: AggregationsHistogramAggregate): TopNSample[] {
   const buckets = new Map();

--- a/src/plugins/profiling/common/topn.ts
+++ b/src/plugins/profiling/common/topn.ts
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import { orderBy } from 'lodash';
+
 import {
   AggregationsHistogramAggregate,
   AggregationsHistogramBucket,
@@ -53,16 +55,7 @@ export function createTopNSamples(histogram: AggregationsHistogramAggregate): To
     }
   }
 
-  // Sort by timestamp ascending, count descending, and category ascending
-  samples.sort((a, b) => {
-    if (a.Timestamp < b.Timestamp) return -1;
-    if (a.Timestamp > b.Timestamp) return 1;
-    if (a.Count > b.Count) return -1;
-    if (a.Count < b.Count) return 1;
-    return a.Category.localeCompare(b.Category);
-  });
-
-  return samples;
+  return orderBy(samples, ['Timestamp', 'Count', 'Category'], ['asc', 'desc', 'asc']);
 }
 
 export function groupSamplesByCategory(samples: TopNSample[]) {

--- a/src/plugins/profiling/common/topn.ts
+++ b/src/plugins/profiling/common/topn.ts
@@ -33,13 +33,15 @@ export function createTopNSamples(histogram: AggregationsHistogramAggregate): To
   const bucketsByTimestamp = new Map();
   const uniqueCategories = new Set<string>();
 
+  // Convert the histogram into nested maps and record the unique categories
   const histogramBuckets = (histogram?.buckets as AggregationsHistogramBucket[]) ?? [];
   for (let i = 0; i < histogramBuckets.length; i++) {
     const frameCountsByCategory = new Map();
-    histogramBuckets[i].group_by.buckets.forEach((item: any) => {
-      uniqueCategories.add(item.key);
-      frameCountsByCategory.set(item.key, item.count.value);
-    });
+    const items = histogramBuckets[i].group_by.buckets;
+    for (let j = 0; j < items.length; j++) {
+      uniqueCategories.add(items[j].key);
+      frameCountsByCategory.set(items[j].key, items[j].count.value);
+    }
     bucketsByTimestamp.set(histogramBuckets[i].key, frameCountsByCategory);
   }
 
@@ -51,7 +53,7 @@ export function createTopNSamples(histogram: AggregationsHistogramAggregate): To
       const sample: TopNSample = {
         Timestamp: timestamp,
         Count: frameCountsByCategory.get(category) ?? 0,
-        Category: category
+        Category: category,
       };
       samples.push(sample);
     }

--- a/src/plugins/profiling/common/topn.ts
+++ b/src/plugins/profiling/common/topn.ts
@@ -30,26 +30,26 @@ interface TopNTraces extends TopNSamples {
 }
 
 export function createTopNSamples(histogram: AggregationsHistogramAggregate): TopNSample[] {
-  const buckets = new Map();
+  const bucketsByTimestamp = new Map();
   const uniqueCategories = new Set<string>();
 
   const histogramBuckets = (histogram?.buckets as AggregationsHistogramBucket[]) ?? [];
   for (let i = 0; i < histogramBuckets.length; i++) {
-    const counts = new Map();
+    const frameCountsByCategory = new Map();
     histogramBuckets[i].group_by.buckets.forEach((item: any) => {
       uniqueCategories.add(item.key);
-      counts.set(item.key, item.count.value);
+      frameCountsByCategory.set(item.key, item.count.value);
     });
-    buckets.set(histogramBuckets[i].key, counts);
+    bucketsByTimestamp.set(histogramBuckets[i].key, frameCountsByCategory);
   }
 
   // Normalize samples so there are an equal number of data points per each timestamp
   const samples: TopNSample[] = [];
-  for (const timestamp of buckets.keys()) {
+  for (const timestamp of bucketsByTimestamp.keys()) {
     for (const category of uniqueCategories.values()) {
       const sample: TopNSample = { Timestamp: timestamp, Count: 0, Category: category };
-      if (buckets.get(timestamp).has(category)) {
-        sample.Count = buckets.get(timestamp).get(category);
+      if (bucketsByTimestamp.get(timestamp).has(category)) {
+        sample.Count = bucketsByTimestamp.get(timestamp).get(category);
       }
       samples.push(sample);
     }

--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -137,7 +137,14 @@ function App({ fetchTopN, fetchElasticFlamechart }: Props) {
               fetchTopN={fetchTopN}
               setTopN={setTopN}
             />
-            <StackedBarChart id="topn" name="topn" height={400} x="Timestamp" y="Count" category="Category" />
+            <StackedBarChart
+              id="topn"
+              name="topn"
+              height={400}
+              x="Timestamp"
+              y="Count"
+              category="Category"
+            />
             <ChartGrid maximum={10} />
           </TopNContext.Provider>
         </>

--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -137,7 +137,7 @@ function App({ fetchTopN, fetchElasticFlamechart }: Props) {
               fetchTopN={fetchTopN}
               setTopN={setTopN}
             />
-            <StackedBarChart id="topn" name="topn" height={400} x="x" y="y" category="g" />
+            <StackedBarChart id="topn" name="topn" height={400} x="Timestamp" y="Count" category="Category" />
             <ChartGrid maximum={10} />
           </TopNContext.Provider>
         </>

--- a/src/plugins/profiling/public/components/stacked-bar-chart.tsx
+++ b/src/plugins/profiling/public/components/stacked-bar-chart.tsx
@@ -46,8 +46,8 @@ export const StackedBarChart: React.FC<StackedBarChartProps> = ({
         data={ctx.samples}
         xAccessor={x}
         yAccessors={[y]}
+        stackAccessors={[x]}
         splitSeriesAccessors={[category]}
-        stackAccessors={[category]}
       />
       <Axis id="bottom-axis" position="bottom" tickFormat={timeFormatter('YYYY-MM-DD HH:mm:ss')} />
       <Axis id="left-axis" position="left" showGridLines tickFormat={(d) => Number(d).toFixed(0)} />

--- a/src/plugins/profiling/public/components/stacktrace-nav.tsx
+++ b/src/plugins/profiling/public/components/stacktrace-nav.tsx
@@ -10,7 +10,8 @@ import React, { useEffect, useState } from 'react';
 
 import { EuiButtonGroup } from '@elastic/eui';
 
-import { getTopN, groupSamplesByCategory } from '../../common';
+import { groupSamplesByCategory } from '../../common';
+import { TopNSample, TopNSamples } from '../../common/topn';
 
 export const StackTraceNavigation = ({ index, projectID, n, timeRange, fetchTopN, setTopN }) => {
   const topnButtonGroupPrefix = 'topnButtonGroup';
@@ -59,11 +60,12 @@ export const StackTraceNavigation = ({ index, projectID, n, timeRange, fetchTopN
 
     console.log(new Date().toISOString(), 'started payload retrieval');
     fetchTopN(topnValue[0].value, index, projectID, timeRange.unixStart, timeRange.unixEnd, n).then(
-      (response) => {
+      (response: TopNSamples) => {
         console.log(new Date().toISOString(), 'finished payload retrieval');
-        const samples = getTopN(response);
+        const samples = response.TopN;
         const series = groupSamplesByCategory(samples);
-        setTopN({ samples, series });
+        const samplesWithoutZero = samples.filter((sample: TopNSample) => sample.Count > 0);
+        setTopN({ samples: samplesWithoutZero, series });
         console.log(new Date().toISOString(), 'updated local state');
       }
     );

--- a/src/plugins/profiling/public/components/stacktrace-nav.tsx
+++ b/src/plugins/profiling/public/components/stacktrace-nav.tsx
@@ -10,8 +10,7 @@ import React, { useEffect, useState } from 'react';
 
 import { EuiButtonGroup } from '@elastic/eui';
 
-import { groupSamplesByCategory } from '../../common';
-import { TopNSample, TopNSamples } from '../../common/topn';
+import { groupSamplesByCategory, TopNSample, TopNSamples } from '../../common/topn';
 
 export const StackTraceNavigation = ({ index, projectID, n, timeRange, fetchTopN, setTopN }) => {
   const topnButtonGroupPrefix = 'topnButtonGroup';

--- a/src/plugins/profiling/server/routes/topn.ts
+++ b/src/plugins/profiling/server/routes/topn.ts
@@ -15,7 +15,7 @@ import {
 import type { DataRequestHandlerContext } from '../../../data/server';
 import { fromMapToRecord, getRoutePaths } from '../../common';
 import { groupStackFrameMetadataByStackTrace, StackTraceID } from '../../common/profiling';
-import { createTopNBucketsByDate } from '../../common/topn';
+import { createTopNSamples } from '../../common/topn';
 import { findDownsampledIndex } from './downsampling';
 import { logExecutionLatency } from './logger';
 import { autoHistogramSumCountOnGroupByField, newProjectTimeQuery } from './query';
@@ -69,11 +69,11 @@ export async function topNElasticSearchQuery(
   );
 
   const histogram = getAggs(resEvents)?.histogram as AggregationsHistogramAggregate;
-  const topN = createTopNBucketsByDate(histogram);
+  const topN = createTopNSamples(histogram);
 
   if (searchField !== 'StackTraceID') {
     return response.ok({
-      body: topN,
+      body: { TopN: topN },
     });
   }
 
@@ -113,7 +113,7 @@ export async function topNElasticSearchQuery(
     );
     return response.ok({
       body: {
-        ...topN,
+        TopN: topN,
         Metadata: metadata,
       },
     });


### PR DESCRIPTION
This PR normalizes the x-axis across all series subcharts in the stacktrace UI as described in https://github.com/elastic/prodfiler/issues/2362.

I also added stronger typing and refactored the server so that the API response requires minimal post-processing by the client.

### Example

The following is a side-by-side comparison of the TopN subcharts before and after normalization of the x-axis.

Before | After
:-------------------------:|:-------------------------:
![before](https://user-images.githubusercontent.com/6038/175608443-3ec115e5-5919-452c-8bd8-ccd59ea3b139.png)  |  ![after](https://user-images.githubusercontent.com/6038/175608456-578ff060-aed9-48d5-b391-0c9a5ce1eb44.png)