### PR TITLE
Display and sort by percentages in TopN subcharts

### DIFF
--- a/src/plugins/profiling/common/topn.ts
+++ b/src/plugins/profiling/common/topn.ts
@@ -74,28 +74,28 @@ export interface TopNSubchart {
 export function groupSamplesByCategory(samples: TopNSample[]): TopNSubchart[] {
   let total = 0;
   const totalPerCategory = new Map<string, number>();
-  const series = new Map<string, CountPerTime[]>();
+  const seriesByCategory = new Map<string, CountPerTime[]>();
 
   for (let i = 0; i < samples.length; i++) {
-    const v = samples[i];
-    if (!series.has(v.Category)) {
-      series.set(v.Category, []);
-      totalPerCategory.set(v.Category, 0);
+    const sample = samples[i];
+    if (!seriesByCategory.has(sample.Category)) {
+      seriesByCategory.set(sample.Category, []);
+      totalPerCategory.set(sample.Category, 0);
     }
-    total += v.Count;
-    totalPerCategory.set(v.Category, totalPerCategory.get(v.Category)! + v.Count);
-    const data = series.get(v.Category)!;
-    data.push({ Timestamp: v.Timestamp, Count: v.Count });
+    total += sample.Count;
+    totalPerCategory.set(sample.Category, totalPerCategory.get(sample.Category)! + sample.Count);
+    const series = seriesByCategory.get(sample.Category)!;
+    series.push({ Timestamp: sample.Timestamp, Count: sample.Count });
   }
 
   const subcharts: TopNSubchart[] = [];
-  for (const [category, data] of series) {
+  for (const [category, series] of seriesByCategory) {
     subcharts.push({
       Category: category,
       Percentage: (totalPerCategory.get(category)! / total) * 100,
-      Series: data,
+      Series: series,
     });
   }
 
-  return orderBy(subcharts, ['Percentage', 'Category'], ['desc', 'asc'])
+  return orderBy(subcharts, ['Percentage', 'Category'], ['desc', 'asc']);
 }

--- a/src/plugins/profiling/common/topn.ts
+++ b/src/plugins/profiling/common/topn.ts
@@ -97,11 +97,5 @@ export function groupSamplesByCategory(samples: TopNSample[]): TopNSubchart[] {
     });
   }
 
-  subcharts.sort((a, b) => {
-    if (a.Percentage > b.Percentage) return -1;
-    if (a.Percentage < b.Percentage) return 1;
-    return a.Category.localeCompare(b.Category);
-  });
-
-  return subcharts;
+  return orderBy(subcharts, ['Percentage', 'Category'], ['desc', 'asc'])
 }

--- a/src/plugins/profiling/common/topn.ts
+++ b/src/plugins/profiling/common/topn.ts
@@ -73,26 +73,24 @@ export interface TopNSubchart {
 
 export function groupSamplesByCategory(samples: TopNSample[]): TopNSubchart[] {
   let total = 0;
-  const totalPerCategory = new Map<string, number>();
   const seriesByCategory = new Map<string, CountPerTime[]>();
 
   for (let i = 0; i < samples.length; i++) {
     const sample = samples[i];
     if (!seriesByCategory.has(sample.Category)) {
       seriesByCategory.set(sample.Category, []);
-      totalPerCategory.set(sample.Category, 0);
     }
     total += sample.Count;
-    totalPerCategory.set(sample.Category, totalPerCategory.get(sample.Category)! + sample.Count);
     const series = seriesByCategory.get(sample.Category)!;
     series.push({ Timestamp: sample.Timestamp, Count: sample.Count });
   }
 
   const subcharts: TopNSubchart[] = [];
   for (const [category, series] of seriesByCategory) {
+    const totalPerCategory = series.reduce((sum, { Count }) => sum + Count, 0);
     subcharts.push({
       Category: category,
-      Percentage: (totalPerCategory.get(category)! / total) * 100,
+      Percentage: (totalPerCategory / total) * 100,
       Series: series,
     });
   }

--- a/src/plugins/profiling/common/topn.ts
+++ b/src/plugins/profiling/common/topn.ts
@@ -72,17 +72,19 @@ export interface TopNSubchart {
 }
 
 export function groupSamplesByCategory(samples: TopNSample[]): TopNSubchart[] {
-  let total = 0;
   const seriesByCategory = new Map<string, CountPerTime[]>();
+  let total = 0;
 
   for (let i = 0; i < samples.length; i++) {
     const sample = samples[i];
+
     if (!seriesByCategory.has(sample.Category)) {
       seriesByCategory.set(sample.Category, []);
     }
-    total += sample.Count;
     const series = seriesByCategory.get(sample.Category)!;
     series.push({ Timestamp: sample.Timestamp, Count: sample.Count });
+
+    total += sample.Count;
   }
 
   const subcharts: TopNSubchart[] = [];

--- a/src/plugins/profiling/common/topn.ts
+++ b/src/plugins/profiling/common/topn.ts
@@ -74,3 +74,16 @@ export function groupSamplesByCategory(samples: TopNSample[]) {
   }
   return series;
 }
+
+export function groupSamplesByCategory(samples: TopNSample[]) {
+  const series = new Map();
+  for (let i = 0; i < samples.length; i++) {
+    const v = samples[i];
+    if (!series.has(v.Category)) {
+      series.set(v.Category, []);
+    }
+    const value = series.get(v.Category);
+    value.push([v.Timestamp, v.Count]);
+  }
+  return series;
+}

--- a/src/plugins/profiling/public/app.tsx
+++ b/src/plugins/profiling/public/app.tsx
@@ -103,7 +103,7 @@ function App({ fetchTopN, fetchElasticFlamechart }: Props) {
 
   const [topn, setTopN] = useState({
     samples: [],
-    series: new Map(),
+    subcharts: [],
   });
 
   const [elasticFlamegraph, setElasticFlamegraph] = useState({});

--- a/src/plugins/profiling/public/components/bar-chart.tsx
+++ b/src/plugins/profiling/public/components/bar-chart.tsx
@@ -29,7 +29,7 @@ export const BarChart: React.FC<BarChartProps> = ({ id, name, height, data, x, y
   return (
     <Chart size={{ height }}>
       <Settings showLegend={false} />
-      <BarSeries id={id} name={name} data={data} xScaleType="time" xAccessor={0} yAccessors={[1]} />
+      <BarSeries id={id} name={name} data={data} xScaleType="time" xAccessor={x} yAccessors={[y]} />
       <Axis id="bottom-axis" position="bottom" tickFormat={timeFormatter('YYYY-MM-DD HH:mm:ss')} />
       <Axis id="left-axis" position="left" showGridLines tickFormat={(d) => Number(d).toFixed(0)} />
     </Chart>

--- a/src/plugins/profiling/public/components/chart-grid.tsx
+++ b/src/plugins/profiling/public/components/chart-grid.tsx
@@ -26,48 +26,49 @@ export interface ChartGridProps {
   maximum: number;
 }
 
+function printSubCharts(subcharts: TopNSubchart[], maximum: number) {
+  const ncharts = Math.min(maximum, subcharts.length);
+
+  const charts = [];
+  for (let i = 0; i < ncharts; i++) {
+    const subchart = subcharts[i];
+    const uniqueID = `bar-chart-${i}`;
+
+    const barchart = (
+      <BarChart
+        id={uniqueID}
+        name={subchart.Category}
+        height={200}
+        data={subchart.Series}
+        x="Timestamp"
+        y="Count"
+      />
+    );
+
+    const title = (
+      <EuiFlexGroup gutterSize="m">
+        <EuiFlexItem grow={false}>
+          <EuiNotificationBadge>{i + 1}</EuiNotificationBadge>
+        </EuiFlexItem>
+        <EuiFlexItem>{subchart.Category}</EuiFlexItem>
+        <EuiFlexItem grow={false}>{subchart.Percentage.toFixed(2)}%</EuiFlexItem>
+      </EuiFlexGroup>
+    );
+
+    const card = (
+      <EuiSplitPanel.Outer>
+        <EuiSplitPanel.Inner>{title}</EuiSplitPanel.Inner>
+        <EuiSplitPanel.Inner>{barchart}</EuiSplitPanel.Inner>
+      </EuiSplitPanel.Outer>
+    );
+
+    charts.push(<EuiFlexItem>{card}</EuiFlexItem>);
+  }
+  return charts;
+}
+
 export const ChartGrid: React.FC<ChartGridProps> = ({ maximum }) => {
   const ctx = useContext(TopNContext);
-  const printSubCharts = (subcharts: TopNSubchart[]) => {
-    const ncharts = Math.min(maximum, subcharts.length);
-
-    const charts = [];
-    for (let i = 0; i < ncharts; i++) {
-      const subchart = subcharts[i];
-      const uniqueID = `bar-chart-${i}`;
-
-      const barchart = (
-        <BarChart
-          id={uniqueID}
-          name={subchart.Category}
-          height={200}
-          data={subchart.Series}
-          x="Timestamp"
-          y="Count"
-        />
-      );
-
-      const title = (
-        <EuiFlexGroup gutterSize="m">
-          <EuiFlexItem grow={false}>
-            <EuiNotificationBadge>{i + 1}</EuiNotificationBadge>
-          </EuiFlexItem>
-          <EuiFlexItem>{subchart.Category}</EuiFlexItem>
-          <EuiFlexItem grow={false}>{subchart.Percentage.toFixed(2)}%</EuiFlexItem>
-        </EuiFlexGroup>
-      );
-
-      const card = (
-        <EuiSplitPanel.Outer>
-          <EuiSplitPanel.Inner>{title}</EuiSplitPanel.Inner>
-          <EuiSplitPanel.Inner>{barchart}</EuiSplitPanel.Inner>
-        </EuiSplitPanel.Outer>
-      );
-
-      charts.push(<EuiFlexItem>{card}</EuiFlexItem>);
-    }
-    return charts;
-  };
 
   useEffect(() => {
     console.log(new Date().toISOString(), 'updated chart-grid');
@@ -81,7 +82,7 @@ export const ChartGrid: React.FC<ChartGridProps> = ({ maximum }) => {
       </EuiTitle>
       <EuiSpacer />
       <EuiFlexGrid columns={2} gutterSize="s">
-        {printSubCharts(ctx.subcharts)}
+        {printSubCharts(ctx.subcharts, maximum)}
       </EuiFlexGrid>
     </>
   );

--- a/src/plugins/profiling/public/components/chart-grid.tsx
+++ b/src/plugins/profiling/public/components/chart-grid.tsx
@@ -9,11 +9,12 @@
 import React, { useContext, useEffect } from 'react';
 
 import {
-  EuiCard,
   EuiFlexGrid,
+  EuiFlexGroup,
   EuiFlexItem,
   EuiNotificationBadge,
   EuiSpacer,
+  EuiSplitPanel,
   EuiTitle,
 } from '@elastic/eui';
 
@@ -41,21 +42,20 @@ export const ChartGrid: React.FC<ChartGridProps> = ({ maximum }) => {
       );
 
       const title = (
-        <div>
-          <EuiNotificationBadge>{i + 1}</EuiNotificationBadge>
-          &emsp;
-          {keys[i]}
-        </div>
+        <EuiFlexGroup gutterSize="m">
+          <EuiFlexItem grow={false}>
+            <EuiNotificationBadge>{i + 1}</EuiNotificationBadge>
+          </EuiFlexItem>
+          <EuiFlexItem>{keys[i]}</EuiFlexItem>
+          <EuiFlexItem grow={false}>100%</EuiFlexItem>
+        </EuiFlexGroup>
       );
 
       const card = (
-        <EuiCard
-          layout="horizontal"
-          onClick={() => {}}
-          title={title}
-          display="plain"
-          description={barchart}
-        />
+        <EuiSplitPanel.Outer>
+          <EuiSplitPanel.Inner>{title}</EuiSplitPanel.Inner>
+          <EuiSplitPanel.Inner>{barchart}</EuiSplitPanel.Inner>
+        </EuiSplitPanel.Outer>
       );
 
       charts.push(<EuiFlexItem>{card}</EuiFlexItem>);

--- a/src/plugins/profiling/public/components/chart-grid.tsx
+++ b/src/plugins/profiling/public/components/chart-grid.tsx
@@ -18,8 +18,9 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 
-import { TopNContext } from './contexts/topn';
 import { BarChart } from './bar-chart';
+import { TopNContext } from './contexts/topn';
+import { TopNSubchart } from '../../common/topn';
 
 export interface ChartGridProps {
   maximum: number;
@@ -27,18 +28,23 @@ export interface ChartGridProps {
 
 export const ChartGrid: React.FC<ChartGridProps> = ({ maximum }) => {
   const ctx = useContext(TopNContext);
-  const printSubCharts = (series: any) => {
-    let keys: string[] = Array.from(series.keys());
-    const ncharts = Math.min(maximum, series.size);
-    keys = keys.slice(0, ncharts);
+  const printSubCharts = (subcharts: TopNSubchart[]) => {
+    const ncharts = Math.min(maximum, subcharts.length);
 
     const charts = [];
     for (let i = 0; i < ncharts; i++) {
-      const subdata = ctx.series.get(keys[i]);
+      const subchart = subcharts[i];
       const uniqueID = `bar-chart-${i}`;
 
       const barchart = (
-        <BarChart id={uniqueID} name={keys[i]} height={200} data={subdata} x="x" y="y" />
+        <BarChart
+          id={uniqueID}
+          name={subchart.Category}
+          height={200}
+          data={subchart.Series}
+          x="Timestamp"
+          y="Count"
+        />
       );
 
       const title = (
@@ -46,8 +52,8 @@ export const ChartGrid: React.FC<ChartGridProps> = ({ maximum }) => {
           <EuiFlexItem grow={false}>
             <EuiNotificationBadge>{i + 1}</EuiNotificationBadge>
           </EuiFlexItem>
-          <EuiFlexItem>{keys[i]}</EuiFlexItem>
-          <EuiFlexItem grow={false}>100%</EuiFlexItem>
+          <EuiFlexItem>{subchart.Category}</EuiFlexItem>
+          <EuiFlexItem grow={false}>{subchart.Percentage.toFixed(2)}%</EuiFlexItem>
         </EuiFlexGroup>
       );
 
@@ -71,11 +77,11 @@ export const ChartGrid: React.FC<ChartGridProps> = ({ maximum }) => {
     <>
       <EuiSpacer />
       <EuiTitle size="s">
-        <h1>Top {ctx.series.size}</h1>
+        <h1>Top {ctx.subcharts.length}</h1>
       </EuiTitle>
       <EuiSpacer />
       <EuiFlexGrid columns={2} gutterSize="s">
-        {printSubCharts(ctx.series)}
+        {printSubCharts(ctx.subcharts)}
       </EuiFlexGrid>
     </>
   );

--- a/src/plugins/profiling/public/components/stacktrace-nav.tsx
+++ b/src/plugins/profiling/public/components/stacktrace-nav.tsx
@@ -62,9 +62,9 @@ export const StackTraceNavigation = ({ index, projectID, n, timeRange, fetchTopN
       (response: TopNSamples) => {
         console.log(new Date().toISOString(), 'finished payload retrieval');
         const samples = response.TopN;
-        const series = groupSamplesByCategory(samples);
+        const subcharts = groupSamplesByCategory(samples);
         const samplesWithoutZero = samples.filter((sample: TopNSample) => sample.Count > 0);
-        setTopN({ samples: samplesWithoutZero, series });
+        setTopN({ samples: samplesWithoutZero, subcharts });
         console.log(new Date().toISOString(), 'updated local state');
       }
     );


### PR DESCRIPTION
This PR displays percentages across all series subcharts in the stacktrace UI as described in https://github.com/elastic/prodfiler/issues/2362. It also sorts the series subcharts by those percentags.

Requires #81 to be merged first

### Example

The following is a side-by-side comparison of the TopN subcharts before and after displaying and sorting by percentages.

Before | After
:-------------------------:|:-------------------------:
![before](https://user-images.githubusercontent.com/6038/175711642-959b5313-5cf3-47f5-b923-0f0ecfe0c829.png)  |  ![after](https://user-images.githubusercontent.com/6038/175712054-15eed3a4-5e26-46a3-8da9-41862c27de10.png)


