### PR TITLE
Switch subcharts from bar series to area series

### DIFF
--- a/src/plugins/profiling/public/components/chart-grid.tsx
+++ b/src/plugins/profiling/public/components/chart-grid.tsx
@@ -18,7 +18,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 
-import { BarChart } from './bar-chart';
+import { SubChart } from './subchart';
 import { TopNContext } from './contexts/topn';
 import { TopNSubchart } from '../../common/topn';
 
@@ -32,10 +32,10 @@ function printSubCharts(subcharts: TopNSubchart[], maximum: number) {
   const charts = [];
   for (let i = 0; i < ncharts; i++) {
     const subchart = subcharts[i];
-    const uniqueID = `bar-chart-${i}`;
+    const uniqueID = `subchart-${i}`;
 
     const barchart = (
-      <BarChart
+      <SubChart
         id={uniqueID}
         name={subchart.Category}
         height={200}

--- a/src/plugins/profiling/public/components/subchart.tsx
+++ b/src/plugins/profiling/public/components/subchart.tsx
@@ -18,11 +18,13 @@ import {
   timeFormatter,
 } from '@elastic/charts';
 
+import { CountPerTime } from '../../common/topn';
+
 export interface SubChartProps {
   id: string;
   name: string;
   height: number;
-  data: any[];
+  data: CountPerTime[];
   x: string;
   y: string;
 }

--- a/src/plugins/profiling/public/components/subchart.tsx
+++ b/src/plugins/profiling/public/components/subchart.tsx
@@ -12,7 +12,7 @@ import { Axis, BarSeries, Chart, Settings } from '@elastic/charts';
 
 import { timeFormatter } from '@elastic/charts';
 
-export interface BarChartProps {
+export interface SubChartProps {
   id: string;
   name: string;
   height: number;
@@ -21,9 +21,9 @@ export interface BarChartProps {
   y: string;
 }
 
-export const BarChart: React.FC<BarChartProps> = ({ id, name, height, data, x, y }) => {
+export const SubChart: React.FC<SubChartProps> = ({ id, name, height, data, x, y }) => {
   useEffect(() => {
-    console.log(new Date().toISOString(), 'updated bar-chart');
+    console.log(new Date().toISOString(), 'updated subchart {name}');
   }, [id, name, height, data, x, y]);
 
   return (

--- a/src/plugins/profiling/public/components/subchart.tsx
+++ b/src/plugins/profiling/public/components/subchart.tsx
@@ -8,9 +8,15 @@
 
 import React, { useEffect } from 'react';
 
-import { AreaSeries, Axis, Chart, CurveType, ScaleType, Settings } from '@elastic/charts';
-
-import { timeFormatter } from '@elastic/charts';
+import {
+  AreaSeries,
+  Axis,
+  Chart,
+  CurveType,
+  ScaleType,
+  Settings,
+  timeFormatter,
+} from '@elastic/charts';
 
 export interface SubChartProps {
   id: string;

--- a/src/plugins/profiling/public/components/subchart.tsx
+++ b/src/plugins/profiling/public/components/subchart.tsx
@@ -8,7 +8,7 @@
 
 import React, { useEffect } from 'react';
 
-import { Axis, BarSeries, Chart, Settings } from '@elastic/charts';
+import { AreaSeries, Axis, Chart, CurveType, ScaleType, Settings } from '@elastic/charts';
 
 import { timeFormatter } from '@elastic/charts';
 
@@ -23,13 +23,23 @@ export interface SubChartProps {
 
 export const SubChart: React.FC<SubChartProps> = ({ id, name, height, data, x, y }) => {
   useEffect(() => {
-    console.log(new Date().toISOString(), 'updated subchart {name}');
+    console.log(new Date().toISOString(), `updated subchart ${name}`);
   }, [id, name, height, data, x, y]);
 
   return (
     <Chart size={{ height }}>
       <Settings showLegend={false} />
-      <BarSeries id={id} name={name} data={data} xScaleType="time" xAccessor={x} yAccessors={[y]} />
+      <AreaSeries
+        id={id}
+        name={name}
+        data={data}
+        xAccessor={x}
+        yAccessors={[y]}
+        xScaleType={ScaleType.Time}
+        yScaleType={ScaleType.Linear}
+        areaSeriesStyle={{ area: { opacity: 0.3 }, line: { opacity: 1 } }}
+        curve={CurveType.CURVE_STEP_AFTER}
+      />
       <Axis id="bottom-axis" position="bottom" tickFormat={timeFormatter('YYYY-MM-DD HH:mm:ss')} />
       <Axis id="left-axis" position="left" showGridLines tickFormat={(d) => Number(d).toFixed(0)} />
     </Chart>


### PR DESCRIPTION
This PR switches to area series across all subcharts in the stacktrace UI as described in https://github.com/elastic/prodfiler/issues/2362.

### Example

The following is a side-by-side comparison of the TopN subcharts before and after switching to area series.

Before | After
:-------------------------:|:-------------------------:
![before](https://user-images.githubusercontent.com/6038/176782219-6980df6f-00ed-4aa4-9a69-93c3b209654b.png)  |  ![after](https://user-images.githubusercontent.com/6038/176782166-d2cd2a50-99b2-4f64-bf21-1fb3504128dd.png)